### PR TITLE
Add basic SHTns C API wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# SHTnsKit.jl 
-Tools for Spherical Harmonics transformation based on SHTns C library.
+# SHTnsKit.jl
+
+Tools for Spherical Harmonics transformation based on the SHTns C library.
+
+## Wrappers
+
+The package currently exposes a minimal set of low-level wrappers around the
+SHTns C API:
+
+- `create_config` – construct a configuration via `shtns_create_with_opts`.
+- `set_grid` – set the spatial grid used for transforms.
+- `sh_to_spat` and `spat_to_sh` – perform synthesis and analysis transforms.
+- `free_config` – release resources allocated for a configuration.
+
+These wrappers expect the `libshtns` shared library to be available on the
+system. They provide the building blocks for higher level Julia interfaces.

--- a/src/SHTnsKit.jl
+++ b/src/SHTnsKit.jl
@@ -1,6 +1,8 @@
 module SHTnsKit
 
-export placeholder_function
+export SHTnsConfig, create_config, set_grid, sh_to_spat, spat_to_sh, free_config
+
+include("api.jl")
 
 include("utils.jl")
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,0 +1,71 @@
+# Low-level wrappers for the SHTns C library
+
+"""SHTns configuration handle."""
+struct SHTnsConfig
+    ptr::Ptr{Cvoid}
+end
+
+# Name of the shared library. Adjust if needed on other platforms.
+const libshtns = "libshtns"
+
+"""
+    create_config(lmax, mmax, mres, flags=UInt32(0)) -> SHTnsConfig
+
+Create a new SHTns configuration using `shtns_create_with_opts`.
+"""
+function create_config(lmax::Integer, mmax::Integer, mres::Integer, flags::UInt32=UInt32(0))
+    cfg = ccall((:shtns_create_with_opts, libshtns), Ptr{Cvoid},
+                (Cint, Cint, Cint, UInt32), lmax, mmax, mres, flags)
+    cfg == C_NULL && error("shtns_create_with_opts returned NULL")
+    return SHTnsConfig(cfg)
+end
+
+"""
+    set_grid(cfg, nlat, nphi, grid_type)
+
+Configure the spatial grid for the transform using `shtns_set_grid`.
+"""
+function set_grid(cfg::SHTnsConfig, nlat::Integer, nphi::Integer, grid_type::Integer)
+    ccall((:shtns_set_grid, libshtns), Cvoid,
+          (Ptr{Cvoid}, Cint, Cint, Cint), cfg.ptr, nlat, nphi, grid_type)
+    return cfg
+end
+
+"""
+    sh_to_spat(cfg, sh, spat)
+
+Perform a synthesis (spectral to spatial) transform using `shtns_sh_to_spat`.
+The arrays `sh` and `spat` must be pre-allocated.
+"""
+function sh_to_spat(cfg::SHTnsConfig, sh::AbstractVector{Float64}, spat::AbstractVector{Float64})
+    ccall((:shtns_sh_to_spat, libshtns), Cvoid,
+          (Ptr{Cvoid}, Ptr{Float64}, Ptr{Float64}), cfg.ptr,
+          Base.unsafe_convert(Ptr{Float64}, sh),
+          Base.unsafe_convert(Ptr{Float64}, spat))
+    return spat
+end
+
+"""
+    spat_to_sh(cfg, spat, sh)
+
+Perform an analysis (spatial to spectral) transform using `shtns_spat_to_sh`.
+The arrays `spat` and `sh` must be pre-allocated.
+"""
+function spat_to_sh(cfg::SHTnsConfig, spat::AbstractVector{Float64}, sh::AbstractVector{Float64})
+    ccall((:shtns_spat_to_sh, libshtns), Cvoid,
+          (Ptr{Cvoid}, Ptr{Float64}, Ptr{Float64}), cfg.ptr,
+          Base.unsafe_convert(Ptr{Float64}, spat),
+          Base.unsafe_convert(Ptr{Float64}, sh))
+    return sh
+end
+
+"""
+    free_config(cfg)
+
+Free resources associated with a configuration using `shtns_free`.
+"""
+function free_config(cfg::SHTnsConfig)
+    ccall((:shtns_free, libshtns), Cvoid, (Ptr{Cvoid},), cfg.ptr)
+    return nothing
+end
+


### PR DESCRIPTION
## Summary
- add thin Julia wrappers for key SHTns C functions (configuration, grid setup, transforms and cleanup)
- document available wrappers and library expectations in README

## Testing
- `julia -e 'include("src/SHTnsKit.jl"); using .SHTnsKit'` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68973f26d4b8832cb8f37df9d1c86795