### PR TITLE
Add additional SHTns API bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ SHTns C API:
 - `create_config` – construct a configuration via `shtns_create_with_opts`.
 - `set_grid` – set the spatial grid used for transforms.
 - `sh_to_spat` and `spat_to_sh` – perform synthesis and analysis transforms.
+- `get_lmax` / `get_mmax` – query maximal degree and order of a configuration.
+- `get_nlat` / `get_nphi` – obtain grid dimensions.
+- `get_nlm` – number of spectral coefficients.
+- `lmidx` – index helper for `(l,m)` pairs.
 - `free_config` – release resources allocated for a configuration.
 
 These wrappers expect the `libshtns` shared library to be available on the

--- a/src/SHTnsKit.jl
+++ b/src/SHTnsKit.jl
@@ -1,6 +1,7 @@
 module SHTnsKit
 
-export SHTnsConfig, create_config, set_grid, sh_to_spat, spat_to_sh, free_config
+export SHTnsConfig, create_config, set_grid, sh_to_spat, spat_to_sh, free_config,
+       get_lmax, get_mmax, get_nlat, get_nphi, get_nlm, lmidx
 
 include("api.jl")
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -60,6 +60,65 @@ function spat_to_sh(cfg::SHTnsConfig, spat::AbstractVector{Float64}, sh::Abstrac
 end
 
 """
+    get_lmax(cfg) -> Int
+
+Return the maximum spherical harmonic degree associated with `cfg` using
+`shtns_get_lmax`.
+"""
+function get_lmax(cfg::SHTnsConfig)
+    return ccall((:shtns_get_lmax, libshtns), Cint, (Ptr{Cvoid},), cfg.ptr)
+end
+
+"""
+    get_mmax(cfg) -> Int
+
+Return the maximum order associated with `cfg` using `shtns_get_mmax`.
+"""
+function get_mmax(cfg::SHTnsConfig)
+    return ccall((:shtns_get_mmax, libshtns), Cint, (Ptr{Cvoid},), cfg.ptr)
+end
+
+"""
+    get_nlat(cfg) -> Int
+
+Retrieve the number of latitudinal grid points set for `cfg` using
+`shtns_get_nlat`.
+"""
+function get_nlat(cfg::SHTnsConfig)
+    return ccall((:shtns_get_nlat, libshtns), Cint, (Ptr{Cvoid},), cfg.ptr)
+end
+
+"""
+    get_nphi(cfg) -> Int
+
+Retrieve the number of longitudinal grid points set for `cfg` using
+`shtns_get_nphi`.
+"""
+function get_nphi(cfg::SHTnsConfig)
+    return ccall((:shtns_get_nphi, libshtns), Cint, (Ptr{Cvoid},), cfg.ptr)
+end
+
+"""
+    get_nlm(cfg) -> Int
+
+Return the number of spherical harmonic coefficients using `shtns_get_nlm`.
+"""
+function get_nlm(cfg::SHTnsConfig)
+    return ccall((:shtns_get_nlm, libshtns), Cint, (Ptr{Cvoid},), cfg.ptr)
+end
+
+"""
+    lmidx(cfg, l, m) -> Int
+
+Return the packed index corresponding to the spherical harmonic degree `l` and
+order `m` using `shtns_lmidx`.
+"""
+function lmidx(cfg::SHTnsConfig, l::Integer, m::Integer)
+    return ccall((:shtns_lmidx, libshtns), Cint,
+                 (Ptr{Cvoid}, Cint, Cint), cfg.ptr, l, m)
+end
+
+"""
     free_config(cfg)
 
 Free resources associated with a configuration using `shtns_free`.


### PR DESCRIPTION
## Summary
- expose configuration query helpers like `get_lmax`, `get_mmax`, `get_nlat`, `get_nphi`, and `get_nlm`
- add `lmidx` to compute packed indices for `(l, m)` pairs
- document the new bindings and export them from the package

## Testing
- `julia -e 'using Pkg; Pkg.test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68988c6a8dd4832cafc0409ab5b381a3