### PR TITLE
AD-safe eltypes and in-place DistAnalysisPlan

### DIFF
--- a/ext/ParallelPlans.jl
+++ b/ext/ParallelPlans.jl
@@ -25,6 +25,24 @@ struct DistAnalysisPlan
     cfg::SHTnsKit.SHTConfig
     prototype_θφ::PencilArray
     use_rfft::Bool
+    # φ-distributed prototypes need the longitude gather; dist_analysis! falls
+    # back to the allocating standard path for them (that layout anti-scales
+    # and already warns).
+    fallback_standard::Bool
+    # Per-call scratch, sized once from cfg + the prototype's local θ slab so
+    # dist_analysis! runs allocation-free after warmup.
+    θ_globals::Vector{Int}
+    weights_cache::Vector{Float64}
+    x_cache::Vector{Float64}
+    P::Vector{Float64}
+    Fθm::Matrix{ComplexF64}
+    Alm_work::Matrix{ComplexF64}
+    θ_is_distributed::Bool
+    # θ-column subcomm for the partial-sum reduction (Comm_split once here
+    # instead of every call). Equals the full communicator when θ is not
+    # distributed or for the fallback path; freed by MPI_Finalize with the
+    # plan's lifetime (plans are long-lived by design).
+    reduce_comm::MPI.Comm
 end
 
 function DistAnalysisPlan(cfg::SHTnsKit.SHTConfig, prototype_θφ::PencilArray; use_rfft::Bool=false, use_packed_storage::Bool=true, with_spatial_scratch::Bool=false)
@@ -32,12 +50,34 @@ function DistAnalysisPlan(cfg::SHTnsKit.SHTConfig, prototype_θφ::PencilArray; 
     # for real inputs/outputs. Case A (φ replicated) uses FFTW.rfft directly;
     # Case B (φ split) uses a row-subcomm gather + FFTW.rfft via
     # distributed_rfft_phi!. Complex-valued callers still use the complex FFT.
-    _validate_cfg_replicated(cfg, communicator(prototype_θφ))
-    # Keep the keyword for API compatibility, but analysis plans currently use
-    # the standard dense-matrix implementation regardless of scratch/packed selection.
+    comm = communicator(prototype_θφ)
+    _validate_cfg_replicated(cfg, comm)
+    # Keep the keywords for API compatibility; the planned path always uses
+    # dense coefficient storage.
     _ = use_packed_storage
     _ = with_spatial_scratch
-    return DistAnalysisPlan(cfg, prototype_θφ, use_rfft)
+    θ_globals = collect(Int, globalindices(prototype_θφ, 1))
+    nθ_local = length(θ_globals)
+    nlon_local = size(parent(prototype_θφ), 2)
+    fallback_standard = nlon_local != cfg.nlon
+    weights_cache = Float64[cfg.w[i] for i in θ_globals]
+    x_cache = Float64[cfg.x[i] for i in θ_globals]
+    P = Vector{Float64}(undef, cfg.lmax + 1)
+    nbins = use_rfft ? (cfg.nlon ÷ 2 + 1) : cfg.nlon
+    Fθm = Matrix{ComplexF64}(undef, nθ_local, nbins)
+    Alm_work = Matrix{ComplexF64}(undef, cfg.lmax + 1, cfg.mmax + 1)
+    θ_is_distributed = nθ_local < cfg.nlat
+    reduce_comm = if θ_is_distributed && !fallback_standard
+        # Reduce only across ranks sharing this φ-segment (see
+        # dist_analysis_standard STEP 5 for the 2D-pencil rationale).
+        φ_globals = globalindices(prototype_θφ, 2)
+        MPI.Comm_split(comm, Int(first(φ_globals)), MPI.Comm_rank(comm))
+    else
+        comm
+    end
+    return DistAnalysisPlan(cfg, prototype_θφ, use_rfft, fallback_standard,
+                            θ_globals, weights_cache, x_cache, P, Fθm, Alm_work,
+                            θ_is_distributed, reduce_comm)
 end
 
 struct DistPlan

--- a/ext/ParallelTransforms.jl
+++ b/ext/ParallelTransforms.jl
@@ -656,8 +656,63 @@ end
 
 
 function SHTnsKit.dist_analysis!(plan::DistAnalysisPlan, Alm_out::AbstractMatrix, fθφ::PencilArray; use_tables=plan.cfg.use_plm_tables)
-    Alm = dist_analysis_standard(plan.cfg, fθφ; use_tables, use_rfft=plan.use_rfft)
-    copyto!(Alm_out, Alm)
+    cfg = plan.cfg
+    if plan.fallback_standard
+        # φ-distributed layout: needs the longitude Allgather; reuse the
+        # allocating standard path (it warns about anti-scaling already).
+        Alm = dist_analysis_standard(cfg, fθφ; use_tables, use_rfft=plan.use_rfft)
+        copyto!(Alm_out, Alm)
+        return Alm_out
+    end
+    lmax, mmax = cfg.lmax, cfg.mmax
+    local_data = parent(fθφ)
+    size(local_data, 1) == length(plan.θ_globals) ||
+        throw(DimensionMismatch("fθφ local θ extent $(size(local_data, 1)) does not match plan ($(length(plan.θ_globals))); build the plan from a prototype with the same Pencil"))
+    size(local_data, 2) == cfg.nlon ||
+        throw(DimensionMismatch("fθφ local φ extent $(size(local_data, 2)) does not match cfg.nlon=$(cfg.nlon)"))
+    size(Alm_out) == (lmax + 1, mmax + 1) ||
+        throw(DimensionMismatch("Alm_out must be ($(lmax+1), $(mmax+1))"))
+
+    # FFT along φ into the plan-owned buffer via the cached-plan helpers
+    # (avoids both the per-call buffer and FFTW re-planning).
+    if plan.use_rfft
+        eltype(local_data) <: Real ||
+            throw(ArgumentError("plan was built with use_rfft=true; fθφ must hold real data"))
+        SHTnsKit.rfft_phi!(plan.Fθm, local_data)
+    else
+        SHTnsKit.fft_phi!(plan.Fθm, local_data)
+    end
+
+    # Legendre integration into the plan-owned work matrix
+    fill!(plan.Alm_work, zero(ComplexF64))
+    use_tbl = use_tables && cfg.use_plm_tables && !isempty(cfg.plm_tables) &&
+              length(cfg.plm_tables) == mmax + 1 && size(cfg.plm_tables[1], 2) == cfg.nlat
+    if use_tbl
+        _analysis_loop_with_tables!(plan.Alm_work, cfg.plm_tables, plan.Fθm,
+                                    plan.weights_cache, plan.θ_globals, lmax, mmax)
+    else
+        _analysis_loop_no_tables!(plan.Alm_work, plan.P, plan.Fθm, plan.weights_cache,
+                                  plan.x_cache, plan.θ_globals, lmax, mmax)
+    end
+
+    # Sum partial θ contributions over the cached θ-column subcomm
+    if plan.θ_is_distributed
+        MPI.Allreduce!(plan.Alm_work, +, plan.reduce_comm)
+    end
+
+    # φ scaling (Nlm already baked into the normalized Legendre rows)
+    cphi = cfg.cphi
+    @inbounds for m in 0:mmax
+        @simd ivdep for l in m:lmax
+            plan.Alm_work[l+1, m+1] *= cphi
+        end
+    end
+
+    if cfg.norm !== :orthonormal || cfg.cs_phase == false
+        SHTnsKit.convert_alm_norm!(Alm_out, plan.Alm_work, cfg; to_internal=false)
+    else
+        copyto!(Alm_out, plan.Alm_work)
+    end
     return Alm_out
 end
 

--- a/src/fftutils.jl
+++ b/src/fftutils.jl
@@ -312,20 +312,13 @@ for `k = 0..nlon÷2`). Falls back to a DFT-then-truncate path when FFTW cannot
 handle the input element type (AD).
 """
 function rfft_phi(A::AbstractMatrix{<:Real})
-    try
-        Y = rfft(A, 2)
-        _FFT_BACKEND[] = _FFT_BACKEND_FFTW
-        return Y
-    catch e
-        if !(e isa MethodError || e isa ArgumentError || e isa InexactError)
-            rethrow(e)
-        end
-        Y_full = _dft_phi(A, -1)
-        nlon = size(A, 2)
-        Y = Y_full[:, 1:(nlon ÷ 2 + 1)]
-        _FFT_BACKEND[] = _FFT_BACKEND_DFT
-        return Y
-    end
+    # Delegate to the in-place variant so the FFTW plan comes from the local
+    # plan cache instead of being rebuilt on every call (bare `rfft(A, 2)`
+    # re-plans each time). The fallback DFT path for AD eltypes is preserved
+    # inside rfft_phi!.
+    nlat, nlon = size(A)
+    dest = Matrix{complex(float(eltype(A)))}(undef, nlat, nlon ÷ 2 + 1)
+    return rfft_phi!(dest, A)
 end
 
 """

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -127,8 +127,10 @@ end
     s_theta = sqrt(max(0.0, 1 - x*x))
     is_pole = s_theta < POLE_TOLERANCE_FACTOR * eps(Float64)
     inv_s_theta = is_pole ? 0.0 : 1.0 / s_theta
-    g_theta = zero(ComplexF64)
-    g_phi = zero(ComplexF64)
+    # Accumulator eltype follows the inputs so AD types propagate.
+    CT = promote_type(eltype(Slm), eltype(Tlm), ComplexF64)
+    g_theta = zero(CT)
+    g_phi = zero(CT)
     Nlm = cfg.Nlm  # hoist field read out of the hot loop (cfg is mutable, so the compiler can't lift it)
     @inbounds for l in max(1, m):ltr
         if is_pole
@@ -150,8 +152,10 @@ end
 `Pb` is a caller-supplied scratch of length ≥ lmax+2 used by the normalized dθ recurrence."""
 @inline function _sphtor_synthesis_kernel_otf(cfg, Slm, Tlm, P, dPdtheta, P_over_sinth, Pb, i, col, m, ltr)
     Plm_norm_dPdtheta_over_sinth_row!(P, dPdtheta, P_over_sinth, cfg.x[i], cfg.lmax, m, Pb)
-    g_theta = zero(ComplexF64)
-    g_phi = zero(ComplexF64)
+    # Accumulator eltype follows the inputs so AD types propagate.
+    CT = promote_type(eltype(Slm), eltype(Tlm), ComplexF64)
+    g_theta = zero(CT)
+    g_phi = zero(CT)
     @inbounds for l in max(1, m):ltr
         dtheta_Y = dPdtheta[l+1]      # already orthonormal-normalized
         Y_over_s = P_over_sinth[l+1]

--- a/src/local.jl
+++ b/src/local.jl
@@ -15,15 +15,19 @@ function SH_to_lat(cfg::SHTConfig, Qlm::AbstractVector{<:Complex}, cost::Real; n
     (0 ≤ mtr ≤ cfg.mmax) || throw(ArgumentError("mtr must be within [0, mmax]"))
     x = float(cost)
     lmax = cfg.lmax
+    # Accumulator/output eltype follows the input so AD types (e.g.
+    # ForwardDiff.Dual) propagate; defaults to Float64 for ComplexF64 input.
+    CT = promote_type(eltype(Qlm), ComplexF64)
+    RT = real(CT)
     P = Vector{Float64}(undef, lmax + 1)
-    vals = Vector{Float64}(undef, nphi)
-    fill!(vals, 0.0)
+    vals = Vector{RT}(undef, nphi)
+    fill!(vals, zero(RT))
 
     need_norm = cfg.norm !== :orthonormal || cfg.cs_phase == false
 
     # m=0 contribution
     Plm_norm_row!(P, x, lmax, 0)
-    g0 = zero(ComplexF64)
+    g0 = zero(CT)
     α0 = need_norm ? cs_phase_factor(0, true, cfg.cs_phase) : 1.0
     @inbounds for l in 0:ltr
         lm = LM_index(lmax, cfg.mres, l, 0) + 1
@@ -42,7 +46,7 @@ function SH_to_lat(cfg::SHTConfig, Qlm::AbstractVector{<:Complex}, cost::Real; n
     for m in 1:mtr
         (m % cfg.mres == 0) || continue
         Plm_norm_row!(P, x, lmax, m)
-        gm = zero(ComplexF64)
+        gm = zero(CT)
         αm = need_norm ? cs_phase_factor(m, true, cfg.cs_phase) : 1.0
         @inbounds for l in m:min(ltr, lmax)
             lm = LM_index(lmax, cfg.mres, l, m) + 1
@@ -69,13 +73,14 @@ function SH_to_lat_cplx(cfg::SHTConfig, alm_packed::AbstractVector{<:Complex}, c
     lmax, mmax = cfg.lmax, cfg.mmax
     length(alm_packed) == nlm_cplx_calc(lmax, mmax, 1) || throw(DimensionMismatch("alm_packed length"))
     x = float(cost)
+    CT = promote_type(eltype(alm_packed), ComplexF64)
     P = Vector{Float64}(undef, lmax + 1)
-    vals = Vector{ComplexF64}(undef, nphi)
-    fill!(vals, zero(ComplexF64))
+    vals = Vector{CT}(undef, nphi)
+    fill!(vals, zero(CT))
     need_norm = cfg.norm !== :orthonormal || cfg.cs_phase == false
     # m=0
     Plm_norm_row!(P, x, lmax, 0)
-    g0 = zero(ComplexF64)
+    g0 = zero(CT)
     α0 = need_norm ? cs_phase_factor(0, true, cfg.cs_phase) : 1.0
     @inbounds for l in 0:min(ltr, lmax)
         idx = LM_cplx_index(lmax, mmax, l, 0) + 1
@@ -93,7 +98,7 @@ function SH_to_lat_cplx(cfg::SHTConfig, alm_packed::AbstractVector{<:Complex}, c
     # m ≠ 0
     for m in 1:mmax
         Plm_norm_row!(P, x, lmax, m)
-        gm = zero(ComplexF64); gn = zero(ComplexF64)
+        gm = zero(CT); gn = zero(CT)
         αp = need_norm ? cs_phase_factor(m, true, cfg.cs_phase) : 1.0
         αn = need_norm ? cs_phase_factor(-m, true, cfg.cs_phase) : 1.0
         @inbounds for l in m:min(ltr, lmax)
@@ -132,6 +137,7 @@ function SHqst_to_point(cfg::SHTConfig, Qlm::AbstractVector{<:Complex}, Slm::Abs
     P = Vector{Float64}(undef, lmax + 1)
     dPdtheta = Vector{Float64}(undef, lmax + 1)
     P_over_sinth = Vector{Float64}(undef, lmax + 1)
+    Pbuf = Vector{Float64}(undef, lmax + 2)  # scratch for the dθ recurrence
     sθ = sqrt(max(0.0, 1 - x*x))
     CT = promote_type(eltype(Qlm), eltype(Slm), eltype(Tlm))
     vr = zero(CT)
@@ -161,7 +167,7 @@ function SHqst_to_point(cfg::SHTConfig, Qlm::AbstractVector{<:Complex}, Slm::Abs
     for m in 1:mmax
         (m % cfg.mres == 0) || continue
         # Single call computes P̄, dP̄/dθ, and P̄/sinθ (avoids redundant Plm_norm_row!)
-        Plm_norm_dPdtheta_over_sinth_row!(P, dPdtheta, P_over_sinth, x, lmax, m)
+        Plm_norm_dPdtheta_over_sinth_row!(P, dPdtheta, P_over_sinth, x, lmax, m, Pbuf)
         gvr = zero(CT)
         gvt = zero(CT)
         gvp = zero(CT)
@@ -198,9 +204,53 @@ Evaluate gradient of a scalar field at a point. Vr is returned as 0.0.
 `DrSlm` is ignored for this pure-Julia core.
 """
 function SH_to_grad_point(cfg::SHTConfig, ::AbstractVector{<:Complex}, Slm::AbstractVector{<:Complex}, cost::Real, phi::Real)
-    zeroQ = zeros(ComplexF64, cfg.nlm)
-    zeroT = zeros(ComplexF64, cfg.nlm)
-    return SHqst_to_point(cfg, zeroQ, Slm, zeroT, cost, phi)
+    length(Slm) == cfg.nlm || throw(DimensionMismatch("Slm length"))
+    x = float(cost)
+    lmax = cfg.lmax; mmax = cfg.mmax
+    P = Vector{Float64}(undef, lmax + 1)
+    dPdtheta = Vector{Float64}(undef, lmax + 1)
+    P_over_sinth = Vector{Float64}(undef, lmax + 1)
+    Pbuf = Vector{Float64}(undef, lmax + 2)  # scratch for the dθ recurrence
+    CT = promote_type(eltype(Slm), ComplexF64)
+    vt = zero(CT)
+    vp = zero(CT)
+
+    need_norm = cfg.norm !== :orthonormal || cfg.cs_phase == false
+
+    # m=0: Vθ = dθY*S; the (im/sinθ)*Y*S term in Vφ vanishes
+    Plm_norm_and_dPdtheta_row!(P, dPdtheta, x, lmax, 0)
+    α0 = need_norm ? cs_phase_factor(0, true, cfg.cs_phase) : 1.0
+    for l in 0:lmax
+        lm = LM_index(lmax, cfg.mres, l, 0) + 1
+        aS = Slm[lm]
+        if need_norm
+            aS *= norm_scale_from_orthonormal(l, 0, cfg.norm) * α0
+        end
+        vt += dPdtheta[l+1] * aS
+    end
+
+    # m>0 (pole-safe 1/sinθ handling)
+    for m in 1:mmax
+        (m % cfg.mres == 0) || continue
+        Plm_norm_dPdtheta_over_sinth_row!(P, dPdtheta, P_over_sinth, x, lmax, m, Pbuf)
+        gvt = zero(CT)
+        gvp = zero(CT)
+        αm = need_norm ? cs_phase_factor(m, true, cfg.cs_phase) : 1.0
+        for l in m:lmax
+            lm = LM_index(lmax, cfg.mres, l, m) + 1
+            aS = Slm[lm]
+            if need_norm
+                aS *= norm_scale_from_orthonormal(l, m, cfg.norm) * αm
+            end
+            # Vθ = dθY*S, Vφ = (im/sinθ)*Y*S (T ≡ 0 for a scalar gradient)
+            gvt += dPdtheta[l+1] * aS
+            gvp += 1.0im * m * P_over_sinth[l+1] * aS
+        end
+        ph = cis(m * phi)
+        vt += 2 * real(gvt * ph)
+        vp += 2 * real(gvp * ph)
+    end
+    return zero(real(CT)), real(vt), real(vp)
 end
 
 """
@@ -219,21 +269,25 @@ function SHqst_to_lat(cfg::SHTConfig, Qlm::AbstractVector{<:Complex}, Slm::Abstr
     (0 ≤ mtr ≤ cfg.mmax) || throw(ArgumentError("mtr must be within [0, mmax]"))
     x = float(cost)
     lmax = cfg.lmax
+    # Accumulator/output eltype follows the inputs so AD types propagate.
+    CT = promote_type(eltype(Qlm), eltype(Slm), eltype(Tlm), ComplexF64)
+    RT = real(CT)
     P = Vector{Float64}(undef, lmax + 1)
     dPdtheta = Vector{Float64}(undef, lmax + 1)
     P_over_sinth = Vector{Float64}(undef, lmax + 1)
-    Vr = Vector{Float64}(undef, nphi)
-    Vt = Vector{Float64}(undef, nphi)
-    Vp = Vector{Float64}(undef, nphi)
-    fill!(Vr, 0.0); fill!(Vt, 0.0); fill!(Vp, 0.0)
+    Pbuf = Vector{Float64}(undef, lmax + 2)  # scratch for the dθ recurrence
+    Vr = Vector{RT}(undef, nphi)
+    Vt = Vector{RT}(undef, nphi)
+    Vp = Vector{RT}(undef, nphi)
+    fill!(Vr, zero(RT)); fill!(Vt, zero(RT)); fill!(Vp, zero(RT))
 
     need_norm = cfg.norm !== :orthonormal || cfg.cs_phase == false
 
     # m=0 (no 1/sinθ terms)
     Plm_norm_and_dPdtheta_row!(P, dPdtheta, x, lmax, 0)
-    g0 = zero(ComplexF64)
-    gθ0 = zero(ComplexF64)
-    gφ0 = zero(ComplexF64)
+    g0 = zero(CT)
+    gθ0 = zero(CT)
+    gφ0 = zero(CT)
     α0 = need_norm ? cs_phase_factor(0, true, cfg.cs_phase) : 1.0
 
     @inbounds for l in 0:ltr
@@ -258,10 +312,10 @@ function SHqst_to_lat(cfg::SHTConfig, Qlm::AbstractVector{<:Complex}, Slm::Abstr
     for m in 1:mtr
         (m % cfg.mres == 0) || continue
         # Single call computes P̄, dP̄/dθ, and P̄/sinθ (avoids redundant Plm_norm_row!)
-        Plm_norm_dPdtheta_over_sinth_row!(P, dPdtheta, P_over_sinth, x, lmax, m)
-        g  = zero(ComplexF64)
-        gθ = zero(ComplexF64)
-        gφ = zero(ComplexF64)
+        Plm_norm_dPdtheta_over_sinth_row!(P, dPdtheta, P_over_sinth, x, lmax, m, Pbuf)
+        g  = zero(CT)
+        gθ = zero(CT)
+        gφ = zero(CT)
         αm = need_norm ? cs_phase_factor(m, true, cfg.cs_phase) : 1.0
 
         @inbounds for l in m:min(ltr, lmax)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -180,7 +180,7 @@ function SH_mul_mx(cfg::SHTConfig, mx::AbstractVector{<:Real}, Qlm::AbstractVect
     @inbounds for lm0 in 0:(cfg.nlm-1)
         l = cfg.li[lm0+1]; m = cfg.mi[lm0+1]  # Get (l,m) for this packed index
 
-        acc = zero(ComplexF64)  # Accumulator for the result
+        acc = zero(promote_type(eltype(Qlm), eltype(Rlm), complex(eltype(mx))))  # eltype-preserving accumulator (AD-safe)
 
         # Contribution from lower degree neighbor Y_{l-1}^m
         # Y_{l-1}^m couples upward to Y_l^m via b_{l-1}^m

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -338,7 +338,9 @@ function synthesis_packed_ml(cfg::SHTConfig, im::Int, Ql::AbstractVector{<:Compl
     expected_len = ltr - im + 1
     length(Ql) == expected_len || throw(DimensionMismatch("Ql length must be $(expected_len)"))
 
-    Vr_m = Vector{ComplexF64}(undef, nlat)
+    # Output eltype follows the input so AD types propagate.
+    CT = promote_type(eltype(Ql), ComplexF64)
+    Vr_m = Vector{CT}(undef, nlat)
     P = Vector{Float64}(undef, ltr + 1)
     inv_scaleφ = phi_inv_scale(cfg)  # Match full transform normalization
     xv = cfg.x  # hoist field reads out of the i/l loops (cfg is mutable, so not auto-hoisted)
@@ -347,7 +349,7 @@ function synthesis_packed_ml(cfg::SHTConfig, im::Int, Ql::AbstractVector{<:Compl
         x = xv[i]
         Plm_norm_row!(P, x, ltr, im)  # P̄ already orthonormal-normalized
 
-        val = zero(ComplexF64)
+        val = zero(CT)
         @inbounds for l in im:ltr
             val += Ql[l-im+1] * P[l+1]
         end
@@ -371,7 +373,9 @@ function synthesis_point(cfg::SHTConfig, Qlm::AbstractMatrix{<:Complex}, cost::R
     size(Qlm, 1) == lmax + 1 || throw(DimensionMismatch("Qlm first dim must be lmax+1"))
     size(Qlm, 2) == mmax + 1 || throw(DimensionMismatch("Qlm second dim must be mmax+1"))
 
-    result = 0.0
+    # Accumulator eltype follows the input so AD types propagate.
+    CT = promote_type(eltype(Qlm), ComplexF64)
+    result = zero(real(CT))
     P = Vector{Float64}(undef, lmax + 1)
 
     # m = 0 contribution (no conjugate partner)
@@ -384,7 +388,7 @@ function synthesis_point(cfg::SHTConfig, Qlm::AbstractMatrix{<:Complex}, cost::R
     for m in 1:mmax
         Plm_norm_row!(P, cost, lmax, m)  # P̄ already orthonormal-normalized
         phase = cis(m * phi)  # e^(imφ)
-        gm = zero(ComplexF64)
+        gm = zero(CT)
         @inbounds for l in m:lmax
             gm += Qlm[l+1, m+1] * P[l+1]
         end

--- a/test/parallel/runtests.jl
+++ b/test/parallel/runtests.jl
@@ -11,12 +11,14 @@
 # - test_mpi_extended.jl       : Extended MPI tests (run separately with mpiexec)
 # - test_transpose_sht.jl      : DistTransposePlan transforms, canonical grid (mpiexec)
 # - test_disttranspose_dealiased.jl : DistTransposePlan on dealiased nlon>2*mmax+1 (mpiexec)
+# - test_dist_plan_alloc.jl    : DistAnalysisPlan correctness + per-call allocation budget (mpiexec)
 #
 # To run MPI tests:
 #   mpiexec -n 4 julia --project test/parallel/test_mpi_comprehensive.jl
 #   mpiexec -n 4 julia --project test/parallel/test_mpi_extended.jl
 #   mpiexec -n 2 julia --project test/parallel/test_transpose_sht.jl
 #   mpiexec -n 2 julia --project test/parallel/test_disttranspose_dealiased.jl
+#   mpiexec -n 2 julia --project test/parallel/test_dist_plan_alloc.jl
 
 using Test
 

--- a/test/parallel/test_dist_plan_alloc.jl
+++ b/test/parallel/test_dist_plan_alloc.jl
@@ -1,0 +1,75 @@
+# DistAnalysisPlan in-place analysis: correctness + per-call allocation budget.
+# Run with:
+#   mpiexec -n 1 julia --project test/parallel/test_dist_plan_alloc.jl
+#   mpiexec -n 2 julia --project test/parallel/test_dist_plan_alloc.jl
+using MPI; MPI.Init()
+using SHTnsKit, PencilArrays, PencilFFTs, Test
+using Random
+
+const comm = MPI.COMM_WORLD
+const rank = MPI.Comm_rank(comm)
+const ParExt = Base.get_extension(SHTnsKit, :SHTnsKitParallelExt)
+
+function band_limited_field(cfg, pen)
+    lmax, mmax = cfg.lmax, cfg.mmax
+    rng = MersenneTwister(7)
+    alm = zeros(ComplexF64, lmax + 1, mmax + 1)
+    for m in 0:mmax, l in m:lmax
+        alm[l+1, m+1] = randn(rng) + im * randn(rng)
+    end
+    alm[:, 1] .= real.(alm[:, 1])
+    MPI.Bcast!(alm, 0, comm)
+    f_full = SHTnsKit.synthesis(cfg, alm; real_output=true)
+    ranges = PencilArrays.range_local(pen)
+    flocal = zeros(Float64, PencilArrays.size_local(pen)...)
+    for (i_local, i_global) in enumerate(ranges[1])
+        for (j_local, j_global) in enumerate(ranges[2])
+            flocal[i_local, j_local] = f_full[i_global, j_global]
+        end
+    end
+    return PencilArray(pen, flocal), f_full
+end
+
+@testset "DistAnalysisPlan θ-decomposed (scaling layout)" begin
+    lmax = 24; nlat = 32; nlon = 72
+    cfg = create_gauss_config(lmax, nlat; nlon=nlon)
+    pen = Pencil((nlat, nlon), (1,), comm)   # decompose θ — the scaling layout
+    f_pa, f_full = band_limited_field(cfg, pen)
+
+    a_ref = SHTnsKit.analysis(cfg, f_full)
+
+    for use_rfft in (false, true)
+        plan = ParExt.DistAnalysisPlan(cfg, f_pa; use_rfft)
+        Alm_out = zeros(ComplexF64, lmax + 1, cfg.mmax + 1)
+        SHTnsKit.dist_analysis!(plan, Alm_out, f_pa)
+        @test maximum(abs.(Alm_out .- a_ref)) < 1e-10
+
+        # match the cfg-form distributed result too
+        Alm_direct = SHTnsKit.dist_analysis(cfg, f_pa; use_rfft)
+        @test maximum(abs.(Alm_out .- Alm_direct)) < 1e-12
+
+        # Allocation budget: plan owns FFT buffer, Legendre scratch, work
+        # matrix, index/weight caches, and the cached reduction subcomm —
+        # per-call allocations must stay far below the ~30 KB the unplanned
+        # path burns (Fθm + Alm zeros + collects + Comm_split).
+        SHTnsKit.dist_analysis!(plan, Alm_out, f_pa)  # warmup
+        a = @allocated SHTnsKit.dist_analysis!(plan, Alm_out, f_pa)
+        rank == 0 && println("dist_analysis! (use_rfft=$use_rfft): $a B/call")
+        @test a < 8192
+    end
+end
+
+@testset "DistAnalysisPlan φ-decomposed (fallback layout)" begin
+    lmax = 16; nlat = 20; nlon = 48
+    cfg = create_gauss_config(lmax, nlat; nlon=nlon)
+    pen = Pencil((nlat, nlon), comm)   # default: decompose last dim (φ)
+    f_pa, f_full = band_limited_field(cfg, pen)
+
+    a_ref = SHTnsKit.analysis(cfg, f_full)
+    plan = ParExt.DistAnalysisPlan(cfg, f_pa)
+    Alm_out = zeros(ComplexF64, lmax + 1, cfg.mmax + 1)
+    SHTnsKit.dist_analysis!(plan, Alm_out, f_pa)
+    @test maximum(abs.(Alm_out .- a_ref)) < 1e-10
+end
+
+rank == 0 && println("test_dist_plan_alloc: all testsets done on $(MPI.Comm_size(comm)) rank(s)")

--- a/test/serial/runtests.jl
+++ b/test/serial/runtests.jl
@@ -30,6 +30,7 @@ using Test
     include("test_vorticity_inverse.jl")
     include("test_gradients.jl")
     include("test_ad_convenience.jl")
+    include("test_eltype_flexibility.jl")
     include("test_turbo.jl")
     include("test_complex_packed.jl")
     include("test_local.jl")

--- a/test/serial/test_eltype_flexibility.jl
+++ b/test/serial/test_eltype_flexibility.jl
@@ -1,0 +1,121 @@
+# SHTnsKit.jl - Element-type flexibility and allocation tests
+# Point/latitude evaluators and operators must propagate the input eltype
+# (e.g. ForwardDiff.Dual) instead of hardcoding ComplexF64/Float64, and the
+# point evaluators must not allocate O(nlm) scratch per call.
+
+using Test
+using SHTnsKit
+using ForwardDiff: Dual, value, partials
+
+@isdefined(VERBOSE) || (const VERBOSE = get(ENV, "SHTNSKIT_TEST_VERBOSE", "0") == "1")
+
+# Complex Dual vector carrying d/dt of (t * base) at t = 1
+_dualize(base::AbstractVector{<:Complex}) =
+    [Complex(Dual(real(z), real(z)), Dual(imag(z), imag(z))) for z in base]
+_dualize(base::AbstractMatrix{<:Complex}) =
+    [Complex(Dual(real(z), real(z)), Dual(imag(z), imag(z))) for z in base]
+
+_value(x::Dual) = value(x)
+_value(z::Complex{<:Dual}) = Complex(value(real(z)), value(imag(z)))
+_partial(x::Dual) = partials(x, 1)
+
+@testset "Eltype flexibility (Dual propagation)" begin
+    lmax = 8
+    nlat = lmax + 4
+    nlon = 2 * lmax + 2
+    cfg = create_gauss_config(lmax, nlat; nlon=nlon)
+    rng_vals = [0.1 * (i + 1) + 0.05im * i for i in 0:(cfg.nlm - 1)]
+    Qlm = collect(ComplexF64, rng_vals)
+    Slm = reverse(Qlm)
+    Tlm = 0.5 .* Qlm
+    cost = 0.3
+
+    @testset "SH_to_lat accepts Dual coefficients" begin
+        Qd = _dualize(Qlm)
+        vals_d = SH_to_lat(cfg, Qd, cost)
+        vals = SH_to_lat(cfg, Qlm, cost)
+        @test _value.(vals_d) ≈ vals
+        # Field is linear in Qlm, so d/dt of (t*Qlm) at t=1 equals the value
+        @test _partial.(vals_d) ≈ vals
+    end
+
+    @testset "SH_to_lat_cplx accepts Dual coefficients" begin
+        nc = SHTnsKit.nlm_cplx_calc(lmax, cfg.mmax, 1)
+        alm = [0.1 * k + 0.02im * k for k in 1:nc]
+        vals = SHTnsKit.SH_to_lat_cplx(cfg, alm, cost)
+        vals_d = SHTnsKit.SH_to_lat_cplx(cfg, _dualize(alm), cost)
+        @test _value.(vals_d) ≈ vals
+        @test _partial.(real.(vals_d)) ≈ real.(vals)
+    end
+
+    @testset "SHqst_to_lat accepts Dual coefficients" begin
+        Vr, Vt, Vp = SHqst_to_lat(cfg, Qlm, Slm, Tlm, cost)
+        Vrd, Vtd, Vpd = SHqst_to_lat(cfg, _dualize(Qlm), _dualize(Slm), _dualize(Tlm), cost)
+        @test _value.(Vrd) ≈ Vr
+        @test _value.(Vtd) ≈ Vt
+        @test _value.(Vpd) ≈ Vp
+        @test _partial.(Vtd) ≈ Vt
+    end
+
+    @testset "synthesis_packed_ml accepts Dual coefficients" begin
+        m = 1
+        Ql = Qlm[1:(lmax - m + 1)]
+        out = synthesis_packed_ml(cfg, m, Ql, lmax)
+        out_d = synthesis_packed_ml(cfg, m, _dualize(Ql), lmax)
+        @test _value.(out_d) ≈ out
+    end
+
+    @testset "synthesis_point is inferable with Dual coefficients" begin
+        Qmat = zeros(ComplexF64, lmax + 1, cfg.mmax + 1)
+        for m in 0:cfg.mmax, l in m:lmax
+            Qmat[l + 1, m + 1] = 0.1 * (l + 1) + 0.03im * m
+        end
+        Qmat_d = _dualize(Qmat)
+        v = synthesis_point(cfg, Qmat, cost, 0.7)
+        vd = @inferred synthesis_point(cfg, Qmat_d, cost, 0.7)
+        @test _value(vd) ≈ v
+        @test _partial(vd) ≈ v
+    end
+
+    @testset "sphtor synthesis kernels are inferable with Dual coefficients" begin
+        Smat = _dualize(zeros(ComplexF64, lmax + 1, cfg.mmax + 1) .+ Slm[1] )
+        Tmat = _dualize(zeros(ComplexF64, lmax + 1, cfg.mmax + 1) .+ Tlm[1])
+        P = Vector{Float64}(undef, lmax + 1)
+        dP = Vector{Float64}(undef, lmax + 1)
+        Ps = Vector{Float64}(undef, lmax + 1)
+        Pb = Vector{Float64}(undef, lmax + 2)
+        gθ, gφ = @inferred SHTnsKit._sphtor_synthesis_kernel_otf(
+            cfg, Smat, Tmat, P, dP, Ps, Pb, 1, 2, 1, lmax)
+        @test isfinite(value(real(gθ)))
+        @test isfinite(value(real(gφ)))
+    end
+
+    @testset "SH_mul_mx accepts Dual coefficients" begin
+        mx = zeros(2 * cfg.nlm)
+        mul_ct_matrix(cfg, mx)
+        R = similar(Qlm)
+        SH_mul_mx(cfg, mx, Qlm, R)
+        Qd = _dualize(Qlm)
+        Rd = similar(Qd)
+        SH_mul_mx(cfg, mx, Qd, Rd)
+        @test _value.(Rd) ≈ R
+    end
+end
+
+@testset "Point evaluator allocations" begin
+    lmax = 32
+    cfg = create_gauss_config(lmax, lmax + 4; nlon=2 * lmax + 2)
+    Slm = [0.1 * (i + 1) + 0.05im * i for i in 0:(cfg.nlm - 1)]
+    Dr = zero(Slm)
+    # Must match the (Q=0, T=0) special case of the general point evaluator
+    vr, vt, vp = SHTnsKit.SH_to_grad_point(cfg, Dr, Slm, 0.3, 0.7)
+    zq = zeros(ComplexF64, cfg.nlm)
+    vr0, vt0, vp0 = SHTnsKit.SHqst_to_point(cfg, zq, Slm, zq, 0.3, 0.7)
+    @test vr == 0.0
+    @test vt ≈ vt0
+    @test vp ≈ vp0
+    a = @allocated SHTnsKit.SH_to_grad_point(cfg, Dr, Slm, 0.3, 0.7)
+    # Must not allocate two O(nlm) zero vectors per call (2*nlm*16 = 17.9 KB
+    # at lmax=32); only the three O(lmax) Legendre rows are acceptable.
+    @test a < 4096
+end


### PR DESCRIPTION
Add an allocation-free DistAnalysisPlan path and broaden numeric eltype support for AD and non-ComplexF64 workflows.

- Extend DistAnalysisPlan with cached buffers, θ indices/weights, work matrices, a reduce subcommunicator and a fallback flag for φ-distributed layouts. Create reduce_comm to avoid repeated Comm_split.
- Implement an in-place, plan-backed SHTnsKit.dist_analysis! that uses cached FFT/Legendre buffers, performs partial θ Allreduce when needed, applies φ-scaling, and avoids per-call allocations (falls back to the allocating standard path for φ-distributed prototypes).
- Change rfft_phi to delegate to the in-place rfft_phi! (preserving the DFT fallback) so FFTW plans come from the local plan cache instead of being replanned each call.
- Replace many hardcoded ComplexF64/Float64 temporaries with promote_type-based accumulators and output buffers (CT/RT) so AD eltypes (e.g. Dual) propagate correctly and functions do not force Float64/ComplexF64.
- Add small per-call scratch buffers (e.g. Pbuf) where required to avoid O(nlm) allocations.
- Update kernels, local/point/gradient evaluators, operators, and transforms to be eltype-preserving and pole-safe.
- Add tests: parallel/test_dist_plan_alloc.jl (dist plan correctness + allocation budget) and serial/test_eltype_flexibility.jl (Dual propagation and allocation checks), and include them in the test runners.

These changes improve allocation behavior for distributed analysis and enable AD usage across point evaluators and operators.