### PR TITLE
Optimize dist sphtor/qst plans and rotations

### DIFF
--- a/ext/ParallelPlans.jl
+++ b/ext/ParallelPlans.jl
@@ -106,6 +106,23 @@ struct DistSphtorPlan
     use_rfft::Bool
     with_spatial_scratch::Bool
     spatial_scratch::Union{Nothing, _SphtorScratch}
+    # --- analysis scratch (always allocated; see DistAnalysisPlan) ---
+    fallback_standard::Bool
+    θ_globals::Vector{Int}
+    x_cache::Vector{Float64}
+    sθ_cache::Vector{Float64}
+    inv_sθ_cache::Vector{Float64}
+    weights_cache::Vector{Float64}
+    P::Vector{Float64}
+    dPdtheta::Vector{Float64}
+    P_over_sth::Vector{Float64}
+    Pbuf::Vector{Float64}
+    Ftθm::Matrix{ComplexF64}
+    Fpθm::Matrix{ComplexF64}
+    Slm_work::Matrix{ComplexF64}
+    Tlm_work::Matrix{ComplexF64}
+    θ_is_distributed::Bool
+    reduce_comm::MPI.Comm
 end
 
 function DistSphtorPlan(cfg::SHTnsKit.SHTConfig, prototype_θφ::PencilArray; with_spatial_scratch::Bool=false, use_rfft::Bool=false)
@@ -113,13 +130,14 @@ function DistSphtorPlan(cfg::SHTnsKit.SHTConfig, prototype_θφ::PencilArray; wi
     # for real inputs/outputs. Case A (φ replicated) uses FFTW.rfft directly;
     # Case B (φ split) uses a row-subcomm gather + FFTW.rfft via
     # distributed_rfft_phi!. Complex-valued callers still use the complex FFT.
-    _validate_cfg_replicated(cfg, communicator(prototype_θφ))
+    comm = communicator(prototype_θφ)
+    _validate_cfg_replicated(cfg, comm)
+    θ_globals = collect(Int, globalindices(prototype_θφ, 1))
+    nθ_local = length(θ_globals)
+    nlon = cfg.nlon
+    lmax = cfg.lmax
     scratch = if with_spatial_scratch
         # Pre-allocate all scratch buffers needed for synthesis
-        θ_globals = collect(globalindices(prototype_θφ, 1))
-        nθ_local = length(θ_globals)
-        nlon = cfg.nlon
-        lmax = cfg.lmax
         (
             Fθ = Matrix{ComplexF64}(undef, nθ_local, nlon),   # Fourier coeffs for Vθ
             Fφ = Matrix{ComplexF64}(undef, nθ_local, nlon),   # Fourier coeffs for Vφ
@@ -131,18 +149,52 @@ function DistSphtorPlan(cfg::SHTnsKit.SHTConfig, prototype_θφ::PencilArray; wi
     else
         nothing
     end
-    return DistSphtorPlan(cfg, prototype_θφ, use_rfft, with_spatial_scratch, scratch)
+    nlon_local = size(parent(prototype_θφ), 2)
+    fallback_standard = nlon_local != nlon
+    x_cache = Vector{Float64}(undef, nθ_local)
+    sθ_cache = Vector{Float64}(undef, nθ_local)
+    inv_sθ_cache = Vector{Float64}(undef, nθ_local)
+    weights_cache = Vector{Float64}(undef, nθ_local)
+    for (ii, iglob) in enumerate(θ_globals)
+        x = cfg.x[iglob]
+        sθ = sqrt(max(0.0, 1 - x * x))
+        x_cache[ii] = x
+        sθ_cache[ii] = sθ
+        inv_sθ_cache[ii] = sθ == 0 ? 0.0 : 1.0 / sθ
+        weights_cache[ii] = cfg.w[iglob]
+    end
+    nbins = use_rfft ? (nlon ÷ 2 + 1) : nlon
+    Ftθm = Matrix{ComplexF64}(undef, nθ_local, nbins)
+    Fpθm = Matrix{ComplexF64}(undef, nθ_local, nbins)
+    Slm_work = Matrix{ComplexF64}(undef, lmax + 1, cfg.mmax + 1)
+    Tlm_work = Matrix{ComplexF64}(undef, lmax + 1, cfg.mmax + 1)
+    θ_is_distributed = nθ_local < cfg.nlat
+    reduce_comm = if θ_is_distributed && !fallback_standard
+        φ_globals = globalindices(prototype_θφ, 2)
+        MPI.Comm_split(comm, Int(first(φ_globals)), MPI.Comm_rank(comm))
+    else
+        comm
+    end
+    return DistSphtorPlan(cfg, prototype_θφ, use_rfft, with_spatial_scratch, scratch,
+                          fallback_standard, θ_globals, x_cache, sθ_cache, inv_sθ_cache,
+                          weights_cache,
+                          Vector{Float64}(undef, lmax + 1), Vector{Float64}(undef, lmax + 1),
+                          Vector{Float64}(undef, lmax + 1), Vector{Float64}(undef, lmax + 2),
+                          Ftθm, Fpθm, Slm_work, Tlm_work, θ_is_distributed, reduce_comm)
 end
 
 struct DistQstPlan
     cfg::SHTnsKit.SHTConfig
     prototype_θφ::PencilArray
     use_rfft::Bool
+    # QST analysis = scalar (radial) + sphtor (tangential); delegate to the
+    # planned sub-transforms so all scratch lives in the sub-plans.
+    scalar_plan::DistAnalysisPlan
+    sphtor_plan::DistSphtorPlan
 end
 
 function DistQstPlan(cfg::SHTnsKit.SHTConfig, prototype_θφ::PencilArray; with_spatial_scratch::Bool=false, use_rfft::Bool=false)
-    # Keep the keyword for API compatibility; QST plans currently do not own
-    # separate scratch storage beyond the scalar/vector sub-transforms.
-    _ = with_spatial_scratch
-    return DistQstPlan(cfg, prototype_θφ, use_rfft)
+    scalar_plan = DistAnalysisPlan(cfg, prototype_θφ; use_rfft)
+    sphtor_plan = DistSphtorPlan(cfg, prototype_θφ; with_spatial_scratch, use_rfft)
+    return DistQstPlan(cfg, prototype_θφ, use_rfft, scalar_plan, sphtor_plan)
 end

--- a/ext/ParallelRotationsPencil.jl
+++ b/ext/ParallelRotationsPencil.jl
@@ -108,45 +108,60 @@ function SHTnsKit.dist_SH_Yrotate_truncgatherm!(cfg::SHTnsKit.SHTConfig,
                                                Alm_pencil::PencilArray,
                                                beta::Real,
                                                R_pencil::PencilArray)
-    lmax, mmax = cfg.lmax, cfg.mmax
+    # Materialize concrete-typed inputs here and run the row loop behind a
+    # function barrier: the globalindices compat wrapper is type-unstable, and
+    # letting it poison the loop costs ~1 MB/call in boxing.
     comm = communicator(Alm_pencil)
-    lloc = axes(Alm_pencil, 1)
-    mloc = axes(Alm_pencil, 2)
-    gl_l = globalindices(Alm_pencil, 1)
-    gl_m = globalindices(Alm_pencil, 2)
+    gl_l = collect(Int, globalindices(Alm_pencil, 1))
+    gl_m = collect(Int, globalindices(Alm_pencil, 2))
+    counts_m = collect(Int, Allgather(length(gl_m), comm))
+    _yrotate_truncgather_rows!(cfg, parent(Alm_pencil), parent(R_pencil),
+                               gl_l, gl_m, counts_m,
+                               MPI.Comm_size(comm), MPI.Comm_rank(comm),
+                               float(beta), comm)
+    return R_pencil
+end
 
+function _yrotate_truncgather_rows!(cfg::SHTnsKit.SHTConfig,
+                                    A_local::AbstractMatrix{ComplexF64},
+                                    R_local::AbstractMatrix{ComplexF64},
+                                    gl_l::Vector{Int}, gl_m::Vector{Int},
+                                    counts_m::Vector{Int}, nranks::Int, myrank::Int,
+                                    beta::Float64, comm)
+    lmax, mmax = cfg.lmax, cfg.mmax
+    # Single exchange of m-ownership counts (done by the caller). The global m
+    # order is the ascending rank-block concatenation (the same invariant
+    # dist_SH_Zrotate's Allgatherv relies on), so each l-row's truncated
+    # per-rank counts are computable locally — one Allgatherv per row instead
+    # of three collectives.
+    nm_local = length(gl_m)
+    counts_l = Vector{Int}(undef, nranks)
+
+    # Hoisted scratch reused across l-rows.
     max_n2 = 2*lmax + 1
+    a_local = Vector{ComplexF64}(undef, nm_local)
+    a_full = Vector{ComplexF64}(undef, mmax + 1)
     b_buf = Vector{ComplexF64}(undef, max_n2)
     c_buf = Vector{ComplexF64}(undef, max_n2)
+    D_buf = Matrix{Float64}(undef, max_n2, max_n2)
 
-    for (ii, il) in enumerate(lloc)
+    for ii in 1:size(A_local, 1)
+        il = ii
         lval = gl_l[ii] - 1
         mm = min(lval, mmax)
-        # Build local subset for m ≤ lval
-        msel_val = Int[]
-        a_loc = ComplexF64[]
-        for (jj, jm) in enumerate(mloc)
-            mval = gl_m[jj] - 1
-            (0 <= mval <= mm) || continue
-            push!(msel_val, mval)
-            push!(a_loc, Alm_pencil[il, jm])
+        # Clip each rank's contiguous m block at mm+1 gathered elements total.
+        off = 0
+        @inbounds for r in 1:nranks
+            counts_l[r] = max(0, min(off + counts_m[r], mm + 1) - off)
+            off += counts_m[r]
         end
-        # Gather sizes
-        count_local = length(msel_val)
-        counts = Allgather(count_local, comm)
-        displs = cumsum([0; counts[1:end-1]])
-        total = sum(counts)
-        m_all = Vector{Int}(undef, total)
-        a_all = Vector{ComplexF64}(undef, total)
-        Allgatherv!(msel_val, VBuffer(m_all, counts), comm)
-        Allgatherv!(a_loc, VBuffer(a_all, counts), comm)
-        # Reconstruct a_full[0:mm]
-        a_full = zeros(ComplexF64, mm + 1)
-        for k in 1:total
-            mval = m_all[k]
-            (0 <= mval <= mm) || continue
-            a_full[mval + 1] = a_all[k]
+        count_local = counts_l[myrank + 1]
+        # Owned m values ascend, so the first count_local columns are m ≤ mm.
+        @inbounds for k in 1:count_local
+            a_local[k] = A_local[il, k]
         end
+        # Gathered blocks land in m order: a_full[m+1] = A[l, m] for m = 0:mm.
+        Allgatherv!(view(a_local, 1:count_local), VBuffer(a_full, counts_l), comm)
         # Build symmetric b of size 2l+1 from positive m part
         n2 = 2*lval + 1
         b = view(b_buf, 1:n2); fill!(b, 0.0 + 0.0im)
@@ -162,8 +177,9 @@ function SHTnsKit.dist_SH_Yrotate_truncgatherm!(cfg::SHTnsKit.SHTConfig,
             b[m + lval + 1] = a_int
             b[-m + lval + 1] = (-1.0)^m * conj(a_int)
         end
-        # d-matrix multiply
-        dl = SHTnsKit.wigner_d_matrix(lval, float(beta))
+        # d-matrix multiply (Wigner-d built into the hoisted buffer)
+        dl = view(D_buf, 1:n2, 1:n2)
+        SHTnsKit.wigner_d_matrix!(dl, lval, beta)
         c = view(c_buf, 1:n2)
         @inbounds for mi in -lval:lval
             acc = 0.0 + 0.0im
@@ -173,19 +189,19 @@ function SHTnsKit.dist_SH_Yrotate_truncgatherm!(cfg::SHTnsKit.SHTConfig,
             c[mi + lval + 1] = acc
         end
         # Write back local columns
-        for (jj, jm) in enumerate(mloc)
+        @inbounds for jj in 1:nm_local
             mval = gl_m[jj] - 1
             if mval <= lval
                 cm = c[mval + lval + 1]
                 km = SHTnsKit.norm_scale_from_orthonormal(lval, mval, cfg.norm)
                 αm = SHTnsKit.cs_phase_factor(mval, true, cfg.cs_phase)
-                R_pencil[il, jm] = cm / (km * αm)
+                R_local[il, jj] = cm / (km * αm)
             else
-                R_pencil[il, jm] = 0.0 + 0.0im
+                R_local[il, jj] = 0.0 + 0.0im
             end
         end
     end
-    return R_pencil
+    return nothing
 end
 function SHTnsKit.dist_SH_Yrotate(cfg::SHTnsKit.SHTConfig,
                                   Alm_pencil::PencilArray,

--- a/ext/ParallelTransforms.jl
+++ b/ext/ParallelTransforms.jl
@@ -943,59 +943,17 @@ function SHTnsKit.dist_analysis_sphtor(cfg::SHTnsKit.SHTConfig, Vtθφ::PencilAr
     Pbuf       = Vector{Float64}(undef, lmax + 2)  # scratch for normalized dθ recurrence
     scaleφ = cfg.cphi
 
-    # Main vector analysis loop
-    for mval in 0:mmax
-        col = mval + 1
-        m_fft = mval + 1  # FFT index for this m mode
-
-        for (ii, iglobθ) in enumerate(θ_globals)
-            # Use pre-cached values
-            x = x_cache[ii]
-            sθ = sθ_cache[ii]
-            inv_sθ = inv_sθ_cache[ii]
-            wi = weights_cache[ii]
-
-            # Get vector components from FFT results
-            Fθ_i = Ftθm[ii, m_fft]
-            Fφ_i = Fpθm[ii, m_fft]
-
-            # Apply Robert form scaling if enabled
-            if cfg.robert_form && sθ > 0
-                Fθ_i /= sθ
-                Fφ_i /= sθ
-            end
-
-            if use_tbl
-                # NP_tables: P̄_l^m already; NdP_tables: -dP̄/dθ/sinθ already.
-                # dθY = -sθ * NdP[l+1, iglobθ]  (matches kernel convention)
-                # Y_over_sθ = NP[l+1, iglobθ] * inv_sθ
-                tblNP  = cfg.NP_tables[col]
-                tblNdP = cfg.NdP_tables[col]
-
-                @inbounds for l in max(1, mval):lmax
-                    dθY      = -sθ * tblNdP[l+1, iglobθ]
-                    Y_over_sθ = tblNP[l+1, iglobθ] * inv_sθ
-                    coeff = wi * scaleφ / (l * (l + 1))
-                    term = (0 + 1im) * mval * Y_over_sθ
-                    # Adjoint of synthesis: Vθ = dθY*S - term*T, Vφ = term*S + dθY*T
-                    Slm_local[l+1, col] += coeff * (Fθ_i * dθY + conj(term) * Fφ_i)
-                    Tlm_local[l+1, col] += coeff * (-conj(term) * Fθ_i + dθY * Fφ_i)
-                end
-            else
-                # OTF: normalized rows — P̄, dP̄/dθ, P̄/sinθ; no extra Nlm multiply.
-                SHTnsKit.Plm_norm_dPdtheta_over_sinth_row!(P, dPdtheta, P_over_sth, x, lmax, mval, Pbuf)
-
-                @inbounds for l in max(1, mval):lmax
-                    dθY      = dPdtheta[l+1]    # dP̄/dθ already orthonormal-normalized
-                    Y_over_sθ = P_over_sth[l+1] # P̄/sinθ
-                    coeff = wi * scaleφ / (l * (l + 1))
-                    term = (0 + 1im) * mval * Y_over_sθ
-                    # Adjoint of synthesis: Vθ = dθY*S - term*T, Vφ = term*S + dθY*T
-                    Slm_local[l+1, col] += coeff * (Fθ_i * dθY + conj(term) * Fφ_i)
-                    Tlm_local[l+1, col] += coeff * (-conj(term) * Fθ_i + dθY * Fφ_i)
-                end
-            end
-        end
+    # Main vector analysis loop — via the same function barriers the planned
+    # path uses (concrete argument types; the previous inline loop boxed its
+    # way to ~2.9 MB/call).
+    if use_tbl
+        _sphtor_analysis_loop_tbl!(Slm_local, Tlm_local, cfg.NP_tables, cfg.NdP_tables,
+                                   Ftθm, Fpθm, θ_globals, sθ_cache, inv_sθ_cache,
+                                   weights_cache, cfg.robert_form, scaleφ, lmax, mmax)
+    else
+        _sphtor_analysis_loop_otf!(Slm_local, Tlm_local, P, dPdtheta, P_over_sth, Pbuf,
+                                   Ftθm, Fpθm, x_cache, sθ_cache, inv_sθ_cache,
+                                   weights_cache, cfg.robert_form, scaleφ, lmax, mmax)
     end
 
     # Only reduce if θ is actually distributed across processes
@@ -1028,10 +986,139 @@ function SHTnsKit.dist_analysis_sphtor(cfg::SHTnsKit.SHTConfig, Vtθφ::PencilAr
     end
 end
 
+# Function barriers for the sphtor analysis accumulation (see the scalar
+# _analysis_loop_* barriers for the rationale: concrete argument types keep the
+# m/θ/l loops allocation-free).
+function _sphtor_analysis_loop_tbl!(Slm::Matrix{ComplexF64}, Tlm::Matrix{ComplexF64},
+                                    NP_tables::Vector{Matrix{Float64}}, NdP_tables::Vector{Matrix{Float64}},
+                                    Ftθm::Matrix{ComplexF64}, Fpθm::Matrix{ComplexF64},
+                                    θ_globals::Vector{Int}, sθ_cache::Vector{Float64},
+                                    inv_sθ_cache::Vector{Float64}, weights_cache::Vector{Float64},
+                                    robert_form::Bool, scaleφ::Float64, lmax::Int, mmax::Int)
+    nθ_local = length(θ_globals)
+    for mval in 0:mmax
+        col = mval + 1
+        tblNP  = NP_tables[col]
+        tblNdP = NdP_tables[col]
+        for ii in 1:nθ_local
+            iglobθ = θ_globals[ii]
+            sθ = sθ_cache[ii]
+            inv_sθ = inv_sθ_cache[ii]
+            wi = weights_cache[ii]
+            Fθ_i = Ftθm[ii, col]
+            Fφ_i = Fpθm[ii, col]
+            if robert_form && sθ > 0
+                Fθ_i /= sθ
+                Fφ_i /= sθ
+            end
+            @inbounds for l in max(1, mval):lmax
+                dθY       = -sθ * tblNdP[l+1, iglobθ]
+                Y_over_sθ = tblNP[l+1, iglobθ] * inv_sθ
+                coeff = wi * scaleφ / (l * (l + 1))
+                term = (0 + 1im) * mval * Y_over_sθ
+                # Adjoint of synthesis: Vθ = dθY*S - term*T, Vφ = term*S + dθY*T
+                Slm[l+1, col] += coeff * (Fθ_i * dθY + conj(term) * Fφ_i)
+                Tlm[l+1, col] += coeff * (-conj(term) * Fθ_i + dθY * Fφ_i)
+            end
+        end
+    end
+    return nothing
+end
+
+function _sphtor_analysis_loop_otf!(Slm::Matrix{ComplexF64}, Tlm::Matrix{ComplexF64},
+                                    P::Vector{Float64}, dPdtheta::Vector{Float64},
+                                    P_over_sth::Vector{Float64}, Pbuf::Vector{Float64},
+                                    Ftθm::Matrix{ComplexF64}, Fpθm::Matrix{ComplexF64},
+                                    x_cache::Vector{Float64}, sθ_cache::Vector{Float64},
+                                    inv_sθ_cache::Vector{Float64}, weights_cache::Vector{Float64},
+                                    robert_form::Bool, scaleφ::Float64, lmax::Int, mmax::Int)
+    nθ_local = length(x_cache)
+    for mval in 0:mmax
+        col = mval + 1
+        for ii in 1:nθ_local
+            sθ = sθ_cache[ii]
+            wi = weights_cache[ii]
+            Fθ_i = Ftθm[ii, col]
+            Fφ_i = Fpθm[ii, col]
+            if robert_form && sθ > 0
+                Fθ_i /= sθ
+                Fφ_i /= sθ
+            end
+            # OTF: normalized rows — P̄, dP̄/dθ, P̄/sinθ; no extra Nlm multiply.
+            SHTnsKit.Plm_norm_dPdtheta_over_sinth_row!(P, dPdtheta, P_over_sth, x_cache[ii], lmax, mval, Pbuf)
+            @inbounds for l in max(1, mval):lmax
+                dθY       = dPdtheta[l+1]
+                Y_over_sθ = P_over_sth[l+1]
+                coeff = wi * scaleφ / (l * (l + 1))
+                term = (0 + 1im) * mval * Y_over_sθ
+                # Adjoint of synthesis: Vθ = dθY*S - term*T, Vφ = term*S + dθY*T
+                Slm[l+1, col] += coeff * (Fθ_i * dθY + conj(term) * Fφ_i)
+                Tlm[l+1, col] += coeff * (-conj(term) * Fθ_i + dθY * Fφ_i)
+            end
+        end
+    end
+    return nothing
+end
+
 function SHTnsKit.dist_analysis_sphtor!(plan::DistSphtorPlan, Slm_out::AbstractMatrix, Tlm_out::AbstractMatrix,
                                          Vtθφ::PencilArray, Vpθφ::PencilArray; use_tables=plan.cfg.use_plm_tables)
-    Slm, Tlm = SHTnsKit.dist_analysis_sphtor(plan.cfg, Vtθφ, Vpθφ; use_tables, use_rfft=plan.use_rfft)
-    copyto!(Slm_out, Slm); copyto!(Tlm_out, Tlm)
+    cfg = plan.cfg
+    if plan.fallback_standard
+        # φ-distributed layout: needs the longitude gather; reuse the allocating
+        # cfg-form path.
+        Slm, Tlm = SHTnsKit.dist_analysis_sphtor(cfg, Vtθφ, Vpθφ; use_tables, use_rfft=plan.use_rfft)
+        copyto!(Slm_out, Slm); copyto!(Tlm_out, Tlm)
+        return Slm_out, Tlm_out
+    end
+    lmax, mmax = cfg.lmax, cfg.mmax
+    local_Vt = parent(Vtθφ)
+    local_Vp = parent(Vpθφ)
+    nθ_local = length(plan.θ_globals)
+    (size(local_Vt, 1) == nθ_local && size(local_Vp, 1) == nθ_local) ||
+        throw(DimensionMismatch("Vt/Vp local θ extent does not match plan ($(nθ_local)); build the plan from a prototype with the same Pencil"))
+    (size(local_Vt, 2) == cfg.nlon && size(local_Vp, 2) == cfg.nlon) ||
+        throw(DimensionMismatch("Vt/Vp local φ extent does not match cfg.nlon=$(cfg.nlon)"))
+    (size(Slm_out) == (lmax + 1, mmax + 1) && size(Tlm_out) == (lmax + 1, mmax + 1)) ||
+        throw(DimensionMismatch("Slm_out/Tlm_out must be ($(lmax+1), $(mmax+1))"))
+
+    if plan.use_rfft
+        (eltype(local_Vt) <: Real && eltype(local_Vp) <: Real) ||
+            throw(ArgumentError("plan was built with use_rfft=true; Vt/Vp must hold real data"))
+        SHTnsKit.rfft_phi!(plan.Ftθm, local_Vt)
+        SHTnsKit.rfft_phi!(plan.Fpθm, local_Vp)
+    else
+        SHTnsKit.fft_phi!(plan.Ftθm, local_Vt)
+        SHTnsKit.fft_phi!(plan.Fpθm, local_Vp)
+    end
+
+    fill!(plan.Slm_work, zero(ComplexF64))
+    fill!(plan.Tlm_work, zero(ComplexF64))
+    use_tbl = use_tables && cfg.use_plm_tables && !isempty(cfg.NP_tables) && !isempty(cfg.NdP_tables) &&
+              length(cfg.NP_tables) == mmax + 1 && length(cfg.NdP_tables) == mmax + 1
+    if use_tbl
+        _sphtor_analysis_loop_tbl!(plan.Slm_work, plan.Tlm_work, cfg.NP_tables, cfg.NdP_tables,
+                                   plan.Ftθm, plan.Fpθm, plan.θ_globals, plan.sθ_cache,
+                                   plan.inv_sθ_cache, plan.weights_cache,
+                                   cfg.robert_form, cfg.cphi, lmax, mmax)
+    else
+        _sphtor_analysis_loop_otf!(plan.Slm_work, plan.Tlm_work, plan.P, plan.dPdtheta,
+                                   plan.P_over_sth, plan.Pbuf, plan.Ftθm, plan.Fpθm,
+                                   plan.x_cache, plan.sθ_cache, plan.inv_sθ_cache,
+                                   plan.weights_cache, cfg.robert_form, cfg.cphi, lmax, mmax)
+    end
+
+    if plan.θ_is_distributed
+        MPI.Allreduce!(plan.Slm_work, +, plan.reduce_comm)
+        MPI.Allreduce!(plan.Tlm_work, +, plan.reduce_comm)
+    end
+
+    if cfg.norm !== :orthonormal || cfg.cs_phase == false
+        SHTnsKit.convert_alm_norm!(Slm_out, plan.Slm_work, cfg; to_internal=false)
+        SHTnsKit.convert_alm_norm!(Tlm_out, plan.Tlm_work, cfg; to_internal=false)
+    else
+        copyto!(Slm_out, plan.Slm_work)
+        copyto!(Tlm_out, plan.Tlm_work)
+    end
     return Slm_out, Tlm_out
 end
 
@@ -1342,8 +1429,9 @@ end
 
 function SHTnsKit.dist_analysis_qst!(plan::DistQstPlan, Qlm_out::AbstractMatrix, Slm_out::AbstractMatrix, Tlm_out::AbstractMatrix,
                                       Vrθφ::PencilArray, Vtθφ::PencilArray, Vpθφ::PencilArray)
-    Q, S, T = SHTnsKit.dist_analysis_qst(plan.cfg, Vrθφ, Vtθφ, Vpθφ)
-    copyto!(Qlm_out, Q); copyto!(Slm_out, S); copyto!(Tlm_out, T)
+    # Delegate to the planned scalar + sphtor paths (all scratch in sub-plans).
+    SHTnsKit.dist_analysis!(plan.scalar_plan, Qlm_out, Vrθφ)
+    SHTnsKit.dist_analysis_sphtor!(plan.sphtor_plan, Slm_out, Tlm_out, Vtθφ, Vpθφ)
     return Qlm_out, Slm_out, Tlm_out
 end
 

--- a/test/parallel/test_dist_plan_alloc.jl
+++ b/test/parallel/test_dist_plan_alloc.jl
@@ -59,6 +59,131 @@ end
     end
 end
 
+@testset "DistSphtorPlan θ-decomposed analysis" begin
+    lmax = 24; nlat = 32; nlon = 72
+    cfg = create_gauss_config(lmax, nlat; nlon=nlon)
+    pen = Pencil((nlat, nlon), (1,), comm)
+
+    rng = MersenneTwister(11)
+    S0 = zeros(ComplexF64, lmax + 1, cfg.mmax + 1)
+    T0 = zeros(ComplexF64, lmax + 1, cfg.mmax + 1)
+    for m in 0:cfg.mmax, l in max(1, m):lmax
+        S0[l+1, m+1] = randn(rng) + im * randn(rng)
+        T0[l+1, m+1] = randn(rng) + im * randn(rng)
+    end
+    S0[:, 1] .= real.(S0[:, 1]); T0[:, 1] .= real.(T0[:, 1])
+    MPI.Bcast!(S0, 0, comm); MPI.Bcast!(T0, 0, comm)
+    Vt_full, Vp_full = SHTnsKit.synthesis_sphtor(cfg, S0, T0; real_output=true)
+
+    ranges = PencilArrays.range_local(pen)
+    Vt_loc = zeros(Float64, PencilArrays.size_local(pen)...)
+    Vp_loc = zeros(Float64, PencilArrays.size_local(pen)...)
+    for (i_local, i_global) in enumerate(ranges[1]), (j_local, j_global) in enumerate(ranges[2])
+        Vt_loc[i_local, j_local] = Vt_full[i_global, j_global]
+        Vp_loc[i_local, j_local] = Vp_full[i_global, j_global]
+    end
+    Vt_pa = PencilArray(pen, Vt_loc)
+    Vp_pa = PencilArray(pen, Vp_loc)
+
+    S_ref, T_ref = SHTnsKit.analysis_sphtor(cfg, Vt_full, Vp_full)
+
+    for use_rfft in (false, true)
+        plan = ParExt.DistSphtorPlan(cfg, Vt_pa; use_rfft)
+        Slm_out = zeros(ComplexF64, lmax + 1, cfg.mmax + 1)
+        Tlm_out = zeros(ComplexF64, lmax + 1, cfg.mmax + 1)
+        SHTnsKit.dist_analysis_sphtor!(plan, Slm_out, Tlm_out, Vt_pa, Vp_pa)
+        @test maximum(abs.(Slm_out .- S_ref)) < 1e-10
+        @test maximum(abs.(Tlm_out .- T_ref)) < 1e-10
+
+        S_direct, T_direct = SHTnsKit.dist_analysis_sphtor(cfg, Vt_pa, Vp_pa; use_rfft)
+        @test maximum(abs.(Slm_out .- S_direct)) < 1e-12
+        @test maximum(abs.(Tlm_out .- T_direct)) < 1e-12
+
+        SHTnsKit.dist_analysis_sphtor!(plan, Slm_out, Tlm_out, Vt_pa, Vp_pa)  # warmup
+        a = @allocated SHTnsKit.dist_analysis_sphtor!(plan, Slm_out, Tlm_out, Vt_pa, Vp_pa)
+        rank == 0 && println("dist_analysis_sphtor! (use_rfft=$use_rfft): $a B/call")
+        @test a < 8192
+    end
+
+    # cfg-form (unplanned) sphtor analysis: legitimately allocates its outputs
+    # and FFT buffers, but must not box through the accumulation loop
+    # (the old inline loop burned ~2.9 MB/call).
+    SHTnsKit.dist_analysis_sphtor(cfg, Vt_pa, Vp_pa)  # warmup
+    a_cfg = @allocated SHTnsKit.dist_analysis_sphtor(cfg, Vt_pa, Vp_pa)
+    rank == 0 && println("dist_analysis_sphtor cfg-form: $a_cfg B/call")
+    @test a_cfg < 300_000
+
+    # Precomputed-tables path must agree with OTF and stay in budget
+    cfg_tbl = create_gauss_config(lmax, nlat; nlon=nlon)
+    SHTnsKit.prepare_plm_tables!(cfg_tbl)
+    plan_tbl = ParExt.DistSphtorPlan(cfg_tbl, Vt_pa)
+    S_tbl = zeros(ComplexF64, lmax + 1, cfg.mmax + 1)
+    T_tbl = zeros(ComplexF64, lmax + 1, cfg.mmax + 1)
+    SHTnsKit.dist_analysis_sphtor!(plan_tbl, S_tbl, T_tbl, Vt_pa, Vp_pa)
+    @test maximum(abs.(S_tbl .- S_ref)) < 1e-10
+    @test maximum(abs.(T_tbl .- T_ref)) < 1e-10
+    SHTnsKit.dist_analysis_sphtor!(plan_tbl, S_tbl, T_tbl, Vt_pa, Vp_pa)  # warmup
+    a_tbl = @allocated SHTnsKit.dist_analysis_sphtor!(plan_tbl, S_tbl, T_tbl, Vt_pa, Vp_pa)
+    rank == 0 && println("dist_analysis_sphtor! (tables): $a_tbl B/call")
+    @test a_tbl < 8192
+
+    # QST plan composes the scalar + sphtor planned paths
+    Vr_pa, _ = band_limited_field(cfg, pen)
+    Qr_ref = SHTnsKit.dist_analysis(cfg, Vr_pa)
+    qplan = ParExt.DistQstPlan(cfg, Vr_pa)
+    Qlm_out = zeros(ComplexF64, lmax + 1, cfg.mmax + 1)
+    Slm_out = zeros(ComplexF64, lmax + 1, cfg.mmax + 1)
+    Tlm_out = zeros(ComplexF64, lmax + 1, cfg.mmax + 1)
+    SHTnsKit.dist_analysis_qst!(qplan, Qlm_out, Slm_out, Tlm_out, Vr_pa, Vt_pa, Vp_pa)
+    @test maximum(abs.(Qlm_out .- Qr_ref)) < 1e-12
+    @test maximum(abs.(Slm_out .- S_ref)) < 1e-10
+    SHTnsKit.dist_analysis_qst!(qplan, Qlm_out, Slm_out, Tlm_out, Vr_pa, Vt_pa, Vp_pa)  # warmup
+    a = @allocated SHTnsKit.dist_analysis_qst!(qplan, Qlm_out, Slm_out, Tlm_out, Vr_pa, Vt_pa, Vp_pa)
+    rank == 0 && println("dist_analysis_qst!: $a B/call")
+    @test a < 16384
+end
+
+@testset "dist_SH_Yrotate pencil form: correctness + allocations" begin
+    lmax = 16
+    β = 0.37
+    cfg = create_gauss_config(lmax, lmax + 2; nlon=2 * lmax + 2)
+    spen = Pencil((lmax + 1, cfg.mmax + 1), comm)   # m distributed (last dim)
+    ranges = PencilArrays.range_local(spen)
+
+    rng = MersenneTwister(3)
+    Qlm = zeros(ComplexF64, cfg.nlm)
+    for m in 0:cfg.mmax, l in m:lmax
+        Qlm[SHTnsKit.LM_index(lmax, 1, l, m) + 1] = randn(rng) + im * randn(rng)
+    end
+    MPI.Bcast!(Qlm, 0, comm)
+
+    Alm_loc = zeros(ComplexF64, PencilArrays.size_local(spen)...)
+    for (i_loc, i_g) in enumerate(ranges[1]), (j_loc, j_g) in enumerate(ranges[2])
+        l = i_g - 1; m = j_g - 1
+        Alm_loc[i_loc, j_loc] = m <= l ? Qlm[SHTnsKit.LM_index(lmax, 1, l, m) + 1] : zero(ComplexF64)
+    end
+    A_pa = PencilArray(spen, Alm_loc)
+    R_pa = PencilArray(spen, zeros(ComplexF64, PencilArrays.size_local(spen)...))
+
+    SHTnsKit.dist_SH_Yrotate(cfg, A_pa, β, R_pa)
+
+    R_ref = zeros(ComplexF64, cfg.nlm)
+    SHTnsKit.SH_Yrotate(cfg, Qlm, β, R_ref)
+    R_loc = parent(R_pa)
+    maxerr = 0.0
+    for (i_loc, i_g) in enumerate(ranges[1]), (j_loc, j_g) in enumerate(ranges[2])
+        l = i_g - 1; m = j_g - 1
+        ref = m <= l ? R_ref[SHTnsKit.LM_index(lmax, 1, l, m) + 1] : zero(ComplexF64)
+        maxerr = max(maxerr, abs(R_loc[i_loc, j_loc] - ref))
+    end
+    @test maxerr < 1e-10
+
+    SHTnsKit.dist_SH_Yrotate(cfg, A_pa, β, R_pa)  # warmup
+    a = @allocated SHTnsKit.dist_SH_Yrotate(cfg, A_pa, β, R_pa)
+    rank == 0 && println("dist_SH_Yrotate: $a B/call")
+    @test a < 65536
+end
+
 @testset "DistAnalysisPlan φ-decomposed (fallback layout)" begin
     lmax = 16; nlat = 20; nlon = 48
     cfg = create_gauss_config(lmax, nlat; nlon=nlon)


### PR DESCRIPTION
Introduce planned DistSphtorPlan fields and caches (θ globals, x/sinθ/inv_sinθ/weights, FFT buffers, Slm/Tlm work, P/dPdtheta buffers, reduce_comm and fallback_standard) to avoid per-call allocations and support θ-distributed analysis. Embed DistQstPlan to hold scalar and sphtor sub-plans and delegate QST analysis to them. Refactor dist_analysis_sphtor! to use the plan (handle fallback layout, rfft vs fft, local FFTs, reductions) and move the heavy m/θ/l accumulation into two concrete-typed function barriers (_sphtor_analysis_loop_tbl! and _sphtor_analysis_loop_otf!) to eliminate boxing/allocations. Factor and optimize Y-rotation path by hoisting typed globalindices and scratch buffers and adding _yrotate_truncgather_rows! to remove repeated collect/allgather overheads. Add tests validating correctness and allocation budgets for the new planned paths and rotation routine.