### PR TITLE
perf: use cached-plan fft_phi! in adjoint and packed FFT paths

### DIFF
--- a/ext/SHTnsKitAdvancedADExt.jl
+++ b/ext/SHTnsKitAdvancedADExt.jl
@@ -145,9 +145,11 @@ end
         nlat, nlon = cfg.nlat, cfg.nlon
         lmax, mmax = cfg.lmax, cfg.mmax
 
-        # Adjoint of ifft_phi: fft_phi
-        F̄θ = SHTnsKit.fft_phi(complex.(V̄t))
-        F̄φ = SHTnsKit.fft_phi(complex.(V̄p))
+        # Adjoint of ifft_phi: fft_phi. One buffer per field + cached FFTW plan
+        # (the old `fft_phi(complex.(V̄))` made a complex copy AND re-planned an
+        # out-of-place fft on every gradient step).
+        F̄θ = SHTnsKit.fft_phi!(Matrix{complex(float(eltype(V̄t)))}(undef, size(V̄t)...), V̄t)
+        F̄φ = SHTnsKit.fft_phi!(Matrix{complex(float(eltype(V̄p)))}(undef, size(V̄p)...), V̄p)
 
         S̄ = zeros(ComplexF64, lmax + 1, mmax + 1)
         T̄ = zeros(ComplexF64, lmax + 1, mmax + 1)

--- a/src/complex_packed.jl
+++ b/src/complex_packed.jl
@@ -156,8 +156,9 @@ function analysis_packed_cplx(cfg::SHTConfig, z::AbstractMatrix{<:Complex})
     alm = Vector{CT}(undef, nlm_cplx_calc(lmax, mmax, 1))
     fill!(alm, zero(CT))
 
-    # FFT along φ
-    Fφ = fft_phi(_as_complex(z))
+    # FFT along φ — one buffer + cached FFTW plan (the bare out-of-place
+    # fft_phi re-plans each call). eltype preserved for the AD/DFT fallback.
+    Fφ = fft_phi!(Matrix{complex(float(eltype(z)))}(undef, size(z)...), z)
     P = Vector{Float64}(undef, lmax + 1)
     scaleφ = cfg.cphi
 

--- a/src/core_transforms.jl
+++ b/src/core_transforms.jl
@@ -437,8 +437,10 @@ function _adjoint_synthesis(cfg::SHTConfig, f̄::AbstractMatrix;
                             real_output::Bool=true)
     lmax, mmax = cfg.lmax, cfg.mmax
     # FFT along φ. For real f̄ the FFTW rfft would be enough, but we accept
-    # complex f̄ too so use the general routine.
-    Fph̄ = fft_phi(_as_complex(f̄))
+    # complex f̄ too so use the general routine. One buffer + cached FFTW plan;
+    # the old `fft_phi(_as_complex(f̄))` made a complex copy AND re-planned an
+    # out-of-place fft each call. eltype preserved for the AD/DFT fallback.
+    Fph̄ = fft_phi!(Matrix{complex(float(eltype(f̄)))}(undef, size(f̄)...), f̄)
     ālm = zeros(ComplexF64, lmax + 1, mmax + 1)
     use_tbl = has_fused_scalar_tables(cfg)
     P = use_tbl ? nothing : Vector{Float64}(undef, lmax + 1)

--- a/test/serial/test_eltype_flexibility.jl
+++ b/test/serial/test_eltype_flexibility.jl
@@ -102,6 +102,41 @@ _partial(x::Dual) = partials(x, 1)
     end
 end
 
+@testset "Adjoint FFT allocations (copy+re-plan pattern)" begin
+    using ChainRulesCore: rrule
+    lmax = 64
+    nlat = lmax + 2
+    nlon = 2 * lmax + 2
+    cfg = create_gauss_config(lmax, nlat; nlon=nlon)
+    matbytes = nlat * nlon * 16
+
+    # _adjoint_synthesis must allocate ONE complex FFT buffer (cached plan),
+    # not a complex copy + an out-of-place re-planned fft result.
+    fbar = randn(nlat, nlon)
+    ref = SHTnsKit._adjoint_synthesis(cfg, fbar)
+    a = @allocated SHTnsKit._adjoint_synthesis(cfg, fbar)
+    @test a < 2 * matbytes  # one buffer + ālm output + slack (was ~2.5 buffers)
+
+    # sphtor synthesis pullback: one buffer per field, not two
+    S = zeros(ComplexF64, lmax + 1, cfg.mmax + 1); S[2, 1] = 1.0
+    T = zeros(ComplexF64, lmax + 1, cfg.mmax + 1); T[3, 2] = 0.5 + 0.25im
+    (y, pb) = rrule(SHTnsKit.synthesis_sphtor, cfg, S, T)
+    Vt, Vp = y
+    _, _, S̄1, T̄1 = pb((Vt, Vp))
+    a2 = @allocated pb((Vt, Vp))
+    @test a2 < 2 * matbytes + 3 * matbytes ÷ 2  # 2 buffers + S̄/T̄ outputs + slack (was ~5 buffers)
+    # adjoint result must be unchanged by the buffer strategy
+    _, _, S̄2, T̄2 = pb((Vt, Vp))
+    @test S̄1 ≈ S̄2 && T̄1 ≈ T̄2
+
+    # analysis_packed_cplx: complex input avoids the copy already; guard that
+    # the cached-plan path returns identical results
+    z = randn(ComplexF64, nlat, nlon)
+    alm1 = analysis_packed_cplx(cfg, z)
+    alm2 = analysis_packed_cplx(cfg, z)
+    @test alm1 ≈ alm2
+end
+
 @testset "Point evaluator allocations" begin
     lmax = 32
     cfg = create_gauss_config(lmax, lmax + 4; nlon=2 * lmax + 2)


### PR DESCRIPTION
fft_phi(complex.(x)) made a full complex copy and re-planned an out-of-place FFT on every call — on the gradient path that cost runs every step. Single preallocated buffer + the cached local plan instead; eltype preserved so AD types keep the DFT fallback.

- _adjoint_synthesis: 343520 -> 205792 B/call
- synthesis_sphtor pullback: 688288 -> 412800 B/call
- analysis_packed_cplx: re-plan eliminated (complex input never copied)