### PR TITLE
Fix correctness, MPI, and AD bugs found in three rounds of auditing

### DIFF
--- a/ext/ParallelLocal.jl
+++ b/ext/ParallelLocal.jl
@@ -264,21 +264,33 @@ end
     dist_analysis_packed_cplx(cfg, z::PencilArray) -> alm_packed (LM_cplx)
 """
 function SHTnsKit.dist_analysis_packed_cplx(cfg::SHTnsKit.SHTConfig, z::PencilArray)
-    # NOTE: this delegates to the REAL-field dist_analysis, so it only represents
-    # a real field's Hermitian spectrum. The negative-m coefficients are therefore
-    # filled from the m≥0 half via a_{l,-m} = (-1)^m conj(a_{l,m}) — the correct
-    # LM_cplx values for a real field. A genuinely complex field (independent ±m)
-    # is NOT supported by this distributed path.
-    Alm = SHTnsKit.dist_analysis(cfg, z; use_tables=cfg.use_plm_tables)
+    cfg.mres == 1 || throw(ArgumentError("LM_cplx layout only defined for mres==1"))
     lmax, mmax = cfg.lmax, cfg.mmax
+    # `dist_analysis` returns the m ≥ 0 columns of exactly this expansion, so the
+    # +m half is already correct for a genuinely complex field. The −m half lives
+    # in φ-FFT bins `dist_analysis` never returns; recover it from
+    #     a_{l,-m}[z] = conj(a_{l,+m}[conj(z)])
+    # which holds because the quadrature weights, P̄_l^{|m|} and the norm scale are
+    # all real and the φ-FFT of conj(z) maps bin −m onto bin +m.
+    #
+    # For a REAL field conj(z) == z, so this collapses to a_{l,-m} = conj(a_{l,m}).
+    # There is NO (-1)^m: this LM_cplx layout uses the SAME P̄_l^{|m|} row for both
+    # signs of m (see `synthesis_packed_cplx` / `SH_to_lat_cplx`), unlike the
+    # Y_l^m convention where the Hermitian relation carries that factor.
+    Aplus = SHTnsKit.dist_analysis(cfg, z; use_tables=cfg.use_plm_tables)
+    Aminus = if eltype(z) <: Real
+        Aplus                       # conj(z) == z — reuse instead of a second transform
+    else
+        zc = similar(z)
+        parent(zc) .= conj.(parent(z))
+        SHTnsKit.dist_analysis(cfg, zc; use_tables=cfg.use_plm_tables)
+    end
     alm_p = Vector{ComplexF64}(undef, SHTnsKit.nlm_cplx_calc(lmax, mmax, 1))
-    # Pack +/- m (Hermitian symmetry for the real field)
     for l in 0:lmax
-        alm_p[SHTnsKit.LM_cplx_index(lmax, mmax, l, 0) + 1] = Alm[l+1, 1]
+        alm_p[SHTnsKit.LM_cplx_index(lmax, mmax, l, 0) + 1] = Aplus[l+1, 1]
         for m in 1:min(l, mmax)
-            ap = Alm[l+1, m+1]
-            alm_p[SHTnsKit.LM_cplx_index(lmax, mmax, l, m) + 1] = ap
-            alm_p[SHTnsKit.LM_cplx_index(lmax, mmax, l, -m) + 1] = ((-1)^m) * conj(ap)
+            alm_p[SHTnsKit.LM_cplx_index(lmax, mmax, l, m) + 1] = Aplus[l+1, m+1]
+            alm_p[SHTnsKit.LM_cplx_index(lmax, mmax, l, -m) + 1] = conj(Aminus[l+1, m+1])
         end
     end
     return alm_p

--- a/ext/ParallelTransforms.jl
+++ b/ext/ParallelTransforms.jl
@@ -216,6 +216,49 @@ end
 # ===== MPI DATA REDISTRIBUTION HELPERS =====
 
 """
+    _owned_range(globals) -> UnitRange{Int}
+
+`first(globals):last(globals)` for the global indices a rank owns along one
+dimension, but safe when the rank owns ZERO of them. That is legitimate whenever
+a pencil has more partitions than the dimension has points (e.g. `nlon = 4` on 5
+ranks), and `first`/`last` on the collected empty vector throw a BoundsError —
+which crashes that rank while its partners sit inside the gather collective, so
+the job hangs instead of failing. An empty range is what the gather helpers
+already expect: `length == 0` contributes a zero-count `Allgatherv` segment.
+"""
+_owned_range(globals) = isempty(globals) ? (1:0) : (Int(first(globals)):Int(last(globals)))
+
+"""
+    _keep_one_phi_partner!(comm, θ_first, arrays...)
+
+Prepare θ-slab partials for a plain full-comm reduction on a 2D (θ×φ) pencil.
+
+Every φ-partner of a θ-slab holds an *identical* spectral partial (the φ gather
+already handed each of them the full longitude), so reducing over the full comm
+would count each slab once per φ-partition. Zeroing all but one partner per
+θ-slab makes the subsequent full-comm sum count each slab exactly once.
+
+This replaces splitting the comm by φ-colour, which had no correct colour for a
+rank owning zero φ columns: `first([])` crashed it, and lumping such ranks under
+a shared colour silently over-counted whenever more than one φ-partition was
+empty. Grouping by θ instead is always well defined — `first` of an empty θ range
+is still a number — and the result is bit-identical to the exact θ-slab sum.
+"""
+function _keep_one_phi_partner!(comm, θ_first::Int, arrays::Vararg{AbstractArray})
+    row_comm = MPI.Comm_split(comm, θ_first, MPI.Comm_rank(comm))
+    try
+        if MPI.Comm_rank(row_comm) != 0
+            for A in arrays
+                fill!(A, zero(eltype(A)))
+            end
+        end
+    finally
+        SHTnsKitParallelExt._safe_comm_free(row_comm)
+    end
+    return nothing
+end
+
+"""
     _gather_and_fft_phi(local_data, θ_range, φ_range, nlon, comm)
 
 Gather data distributed along φ dimension, then perform FFT along φ.
@@ -460,8 +503,8 @@ Decompose latitude instead: `SHTnsKit.create_spatial_pencil(cfg; comm)` or `Penc
             Fθm .= FFTW.rfft(local_data, 2)
         else
             φ_globals = collect(globalindices(fθφ, 2))
-            φ_range = first(φ_globals):last(φ_globals)
-            θ_range = first(θ_globals):last(θ_globals)
+            φ_range = _owned_range(φ_globals)
+            θ_range = _owned_range(θ_globals)
             SHTnsKitParallelExt.distributed_rfft_phi!(Fθm, local_data, θ_range, φ_range, nlon, comm)
         end
     elseif nlon_local == nlon
@@ -472,8 +515,8 @@ Decompose latitude instead: `SHTnsKit.create_spatial_pencil(cfg; comm)` or `Penc
         # CASE B: Data distributed along φ — gather full longitude rows before FFT.
         Fθm = Matrix{ComplexF64}(undef, nlat_local, nlon)
         φ_globals = collect(globalindices(fθφ, 2))
-        φ_range = first(φ_globals):last(φ_globals)
-        θ_range = first(θ_globals):last(θ_globals)
+        φ_range = _owned_range(φ_globals)
+        θ_range = _owned_range(θ_globals)
         Fθm = _gather_and_fft_phi(local_data, θ_range, φ_range, nlon, comm)
     end
 
@@ -542,7 +585,10 @@ Decompose latitude instead: `SHTnsKit.create_spatial_pencil(cfg; comm)` or `Penc
         # Original inline loop for packed storage (not the hot path).
         # Uses normalized rows (Plm_norm_row! / NP_tables): Nlm is already baked in.
         xv = cfg.x; cphi = cfg.cphi  # hoist field reads out of the loops below (cfg is mutable, so not auto-hoisted)
-        for mval in 0:mmax
+        # Stride by mres: create_packed_storage_info only assigns lm_to_packed for
+        # m % mres == 0, leaving every other entry 0. Walking all m under @inbounds
+        # therefore wrote Alm_local[0] — one element before the buffer.
+        for mval in 0:cfg.mres:mmax
             col = mval + 1
             m_fft = mval + 1
             for (ii, iglob) in enumerate(θ_globals)
@@ -582,30 +628,19 @@ Decompose latitude instead: `SHTnsKit.create_spatial_pencil(cfg; comm)` or `Penc
     θ_is_distributed = (nθ_local < nlat)
 
     if θ_is_distributed
-        # Reduce only across ranks that share this rank's φ-segment (they differ
-        # in θ), so a 2D (θ×φ) pencil sums each θ-slab exactly once. φ-partners
-        # that hold the same θ-slab carry identical post-gather contributions, so
-        # reducing over the full comm would overcount by the φ-partition factor.
-        # For a 1D θ-only split φ is complete on every rank, so first(φ_globals)
-        # is identical everywhere → this column subcomm equals the full comm and
-        # the previous behaviour is preserved exactly.
+        # φ-partners that hold the same θ-slab carry identical post-gather
+        # contributions, so a full-comm reduction would overcount by the
+        # φ-partition factor. Drop all but one partner per θ-slab first.
         if nlon_local == nlon
-            # θ-only decomposition: φ is complete on every rank, so the per-φ-column
-            # subcomm equals the full comm. Reduce directly and skip the per-call
+            # θ-only decomposition: φ is complete on every rank, so there are no
+            # φ-partners to dedup. Reduce directly and skip the per-call
             # MPI.Comm_split (a synchronizing collective) entirely.
             SHTnsKitParallelExt.efficient_spectral_reduce!(Alm_local, comm)
         else
-            # 2D (θ×φ) pencil: group ranks by φ-partition so each θ-slab is summed
-            # exactly once. `color` guards a rank that legitimately owns zero φ
-            # columns (p2 > nlon) so first([]) can't crash it before the collective.
-            φ_globals_red = collect(globalindices(fθφ, 2))
-            color = isempty(φ_globals_red) ? 0 : Int(first(φ_globals_red))
-            reduce_comm = MPI.Comm_split(comm, color, MPI.Comm_rank(comm))
-            try
-                SHTnsKitParallelExt.efficient_spectral_reduce!(Alm_local, reduce_comm)
-            finally
-                SHTnsKitParallelExt._safe_comm_free(reduce_comm)
-            end
+            # 2D (θ×φ) pencil: keep one partner per θ-slab, then reduce over the
+            # full comm so each slab is summed exactly once.
+            _keep_one_phi_partner!(comm, first(_owned_range(θ_globals)), Alm_local)
+            SHTnsKitParallelExt.efficient_spectral_reduce!(Alm_local, comm)
         end
         if !use_packed_storage
             # Apply φ scaling (cphi = 2π/nlon). Nlm is NOT applied here: the
@@ -634,7 +669,9 @@ Decompose latitude instead: `SHTnsKit.create_spatial_pencil(cfg; comm)` or `Penc
             # can't take it (was a MethodError). Apply the identical internal→cfg
             # scaling (divide by M = norm_scale·cs_phase) per (l,m) in place.
             M = SHTnsKit._ensure_norm_scale_matrix!(cfg)
-            @inbounds for m in 0:mmax, l in m:lmax
+            # Same mres stride as the accumulation loop above — lm_to_packed is 0
+            # for every m that is not a multiple of mres.
+            @inbounds for m in 0:cfg.mres:mmax, l in m:lmax
                 Alm_local[storage_info.lm_to_packed[l+1, m+1]] /= M[l+1, m+1]
             end
             return Alm_local
@@ -855,7 +892,7 @@ function SHTnsKit.dist_synthesis(cfg::SHTnsKit.SHTConfig, Alm::AbstractMatrix; p
     else
         # φ is distributed - extract local portion
         φ_globals = collect(globalindices(prototype_θφ, 2))
-        local_φ_range = first(φ_globals):last(φ_globals)
+        local_φ_range = _owned_range(φ_globals)
         result = fθφ_local[:, local_φ_range]
         if !real_output
             result = Complex{Float64}.(result)
@@ -910,8 +947,8 @@ function SHTnsKit.dist_analysis_sphtor(cfg::SHTnsKit.SHTConfig, Vtθφ::PencilAr
             Fpθm .= FFTW.rfft(local_Vp, 2)
         else
             φ_globals = collect(globalindices(Vtθφ, 2))
-            φ_range = first(φ_globals):last(φ_globals)
-            θ_range = first(θ_globals):last(θ_globals)
+            φ_range = _owned_range(φ_globals)
+            θ_range = _owned_range(θ_globals)
             SHTnsKitParallelExt.distributed_rfft_phi!(Ftθm, local_Vt, θ_range, φ_range, nlon, comm)
             SHTnsKitParallelExt.distributed_rfft_phi!(Fpθm, local_Vp, θ_range, φ_range, nlon, comm)
         end
@@ -920,8 +957,8 @@ function SHTnsKit.dist_analysis_sphtor(cfg::SHTnsKit.SHTConfig, Vtθφ::PencilAr
         SHTnsKitParallelExt.fft_along_dim2!(Fpθm, local_Vp)
     else
         φ_globals = collect(globalindices(Vtθφ, 2))
-        φ_range = first(φ_globals):last(φ_globals)
-        θ_range = first(θ_globals):last(θ_globals)
+        φ_range = _owned_range(φ_globals)
+        θ_range = _owned_range(θ_globals)
         Ftθm = _gather_and_fft_phi(local_Vt, θ_range, φ_range, nlon, comm)
         Fpθm = _gather_and_fft_phi(local_Vp, θ_range, φ_range, nlon, comm)
     end
@@ -967,8 +1004,8 @@ function SHTnsKit.dist_analysis_sphtor(cfg::SHTnsKit.SHTConfig, Vtθφ::PencilAr
     # way to ~2.9 MB/call).
     if use_tbl
         _sphtor_analysis_loop_tbl!(Slm_local, Tlm_local, cfg.NP_tables, cfg.NdP_tables,
-                                   Ftθm, Fpθm, θ_globals, sθ_cache, inv_sθ_cache,
-                                   weights_cache, cfg.robert_form, scaleφ, lmax, mmax)
+                                   Ftθm, Fpθm, θ_globals, x_cache, sθ_cache, inv_sθ_cache,
+                                   weights_cache, cfg.Nlm, cfg.robert_form, scaleφ, lmax, mmax)
     else
         _sphtor_analysis_loop_otf!(Slm_local, Tlm_local, P, dPdtheta, P_over_sth, Pbuf,
                                    Ftθm, Fpθm, x_cache, sθ_cache, inv_sθ_cache,
@@ -980,17 +1017,17 @@ function SHTnsKit.dist_analysis_sphtor(cfg::SHTnsKit.SHTConfig, Vtθφ::PencilAr
     θ_is_distributed = (nθ_local < nlat)
 
     if θ_is_distributed
-        # Reduce over the θ-column subcomm (ranks sharing this φ-segment) so a 2D
-        # (θ×φ) pencil sums each θ-slab once instead of once per φ-partner. For a
-        # 1D θ-only split this column subcomm equals the full comm (see the scalar
-        # dist_analysis_standard reduction for the detailed rationale).
-        φ_globals_red = collect(globalindices(Vtθφ, 2))
-        reduce_comm = MPI.Comm_split(comm, Int(first(φ_globals_red)), MPI.Comm_rank(comm))
-        try
-            SHTnsKitParallelExt.efficient_spectral_reduce!(Slm_local, reduce_comm)
-            SHTnsKitParallelExt.efficient_spectral_reduce!(Tlm_local, reduce_comm)
-        finally
-            SHTnsKitParallelExt._safe_comm_free(reduce_comm)
+        # Same dedup-then-reduce as the scalar dist_analysis_standard path (see
+        # there for the rationale): on a 2D (θ×φ) pencil the φ-partners of a
+        # θ-slab hold identical partials, so keep one per slab before summing.
+        if nlon_local == nlon
+            # θ-only decomposition: no φ-partners, so skip the MPI.Comm_split.
+            SHTnsKitParallelExt.efficient_spectral_reduce!(Slm_local, comm)
+            SHTnsKitParallelExt.efficient_spectral_reduce!(Tlm_local, comm)
+        else
+            _keep_one_phi_partner!(comm, first(_owned_range(θ_globals)), Slm_local, Tlm_local)
+            SHTnsKitParallelExt.efficient_spectral_reduce!(Slm_local, comm)
+            SHTnsKitParallelExt.efficient_spectral_reduce!(Tlm_local, comm)
         end
     end
 
@@ -1011,8 +1048,10 @@ end
 function _sphtor_analysis_loop_tbl!(Slm::Matrix{ComplexF64}, Tlm::Matrix{ComplexF64},
                                     NP_tables::Vector{Matrix{Float64}}, NdP_tables::Vector{Matrix{Float64}},
                                     Ftθm::Matrix{ComplexF64}, Fpθm::Matrix{ComplexF64},
-                                    θ_globals::Vector{Int}, sθ_cache::Vector{Float64},
+                                    θ_globals::Vector{Int}, x_cache::Vector{Float64},
+                                    sθ_cache::Vector{Float64},
                                     inv_sθ_cache::Vector{Float64}, weights_cache::Vector{Float64},
+                                    Nlm::Matrix{Float64},
                                     robert_form::Bool, scaleφ::Float64, lmax::Int, mmax::Int)
     nθ_local = length(θ_globals)
     for mval in 0:mmax
@@ -1030,9 +1069,21 @@ function _sphtor_analysis_loop_tbl!(Slm::Matrix{ComplexF64}, Tlm::Matrix{Complex
                 Fθ_i /= sθ
                 Fφ_i /= sθ
             end
+            # At an exact pole node (pole-inclusive regular/DH grids) sinθ == 0, so
+            # the stored tables carry the guarded 0 rather than the true limit —
+            # reading them there would silently zero the whole m=1 contribution.
+            # Use the same closed forms the serial kernels use (src/kernels.jl).
+            xi = x_cache[ii]
+            is_pole = sθ < SHTnsKit.POLE_TOLERANCE_FACTOR * eps(Float64)
             @inbounds for l in max(1, mval):lmax
-                dθY       = -sθ * tblNdP[l+1, iglobθ]
-                Y_over_sθ = tblNP[l+1, iglobθ] * inv_sθ
+                if is_pole
+                    N = Nlm[l+1, col]
+                    dθY       = SHTnsKit._dPdtheta_at_pole(l, mval, xi, N)
+                    Y_over_sθ = SHTnsKit._P_over_sinth_at_pole(l, mval, xi, N)
+                else
+                    dθY       = -sθ * tblNdP[l+1, iglobθ]
+                    Y_over_sθ = tblNP[l+1, iglobθ] * inv_sθ
+                end
                 coeff = wi * scaleφ / (l * (l + 1))
                 term = (0 + 1im) * mval * Y_over_sθ
                 # Adjoint of synthesis: Vθ = dθY*S - term*T, Vφ = term*S + dθY*T
@@ -1116,9 +1167,9 @@ function SHTnsKit.dist_analysis_sphtor!(plan::DistSphtorPlan, Slm_out::AbstractM
               length(cfg.NP_tables) == mmax + 1 && length(cfg.NdP_tables) == mmax + 1
     if use_tbl
         _sphtor_analysis_loop_tbl!(plan.Slm_work, plan.Tlm_work, cfg.NP_tables, cfg.NdP_tables,
-                                   plan.Ftθm, plan.Fpθm, plan.θ_globals, plan.sθ_cache,
-                                   plan.inv_sθ_cache, plan.weights_cache,
-                                   cfg.robert_form, cfg.cphi, lmax, mmax)
+                                   plan.Ftθm, plan.Fpθm, plan.θ_globals, plan.x_cache,
+                                   plan.sθ_cache, plan.inv_sθ_cache, plan.weights_cache,
+                                   cfg.Nlm, cfg.robert_form, cfg.cphi, lmax, mmax)
     else
         _sphtor_analysis_loop_otf!(plan.Slm_work, plan.Tlm_work, plan.P, plan.dPdtheta,
                                    plan.P_over_sth, plan.Pbuf, plan.Ftθm, plan.Fpθm,
@@ -1202,15 +1253,26 @@ function SHTnsKit.dist_synthesis_sphtor(cfg::SHTnsKit.SHTConfig, Slm::AbstractMa
                 tblNP  = cfg.NP_tables[col]
                 tblNdP = cfg.NdP_tables[col]
 
+                # sinθ == 0 at an exact pole node (pole-inclusive regular/DH grids):
+                # the tables hold the guarded 0 there, not the true limit, so reading
+                # them would silently zero the entire m=1 contribution on those rows.
+                # Use the closed forms the serial kernels use (src/kernels.jl).
+                is_pole = sθ < SHTnsKit.POLE_TOLERANCE_FACTOR * eps(Float64)
                 @inbounds for l in max(1, mval):lmax
-                    dθY = -sθ * tblNdP[l+1, iglobθ]
-                    Y   = tblNP[l+1, iglobθ]
+                    if is_pole
+                        N = cfg.Nlm[l+1, col]
+                        dθY       = SHTnsKit._dPdtheta_at_pole(l, mval, x, N)
+                        Y_over_sθ = SHTnsKit._P_over_sinth_at_pole(l, mval, x, N)
+                    else
+                        dθY       = -sθ * tblNdP[l+1, iglobθ]
+                        Y_over_sθ = tblNP[l+1, iglobθ] * inv_sθ
+                    end
                     Sl = Slm[l+1, col]
                     Tl = Tlm[l+1, col]
                     # Vθ = ∂S/∂θ - (im/sinθ) * T
-                    gθ += dθY * Sl - (0 + 1im) * mval * inv_sθ * Y * Tl
+                    gθ += dθY * Sl - (0 + 1im) * mval * Y_over_sθ * Tl
                     # Vφ = (im/sinθ) * S + ∂T/∂θ
-                    gφ += (0 + 1im) * mval * inv_sθ * Y * Sl + dθY * Tl
+                    gφ += (0 + 1im) * mval * Y_over_sθ * Sl + dθY * Tl
                 end
             else
                 # OTF: normalized rows — P̄, dP̄/dθ, P̄/sinθ; no extra Nlm multiply.
@@ -1270,7 +1332,7 @@ function SHTnsKit.dist_synthesis_sphtor(cfg::SHTnsKit.SHTConfig, Slm::AbstractMa
         Vpθφ = real_output ? Vpθφ_local : Complex{Float64}.(Vpθφ_local)
     else
         φ_globals = collect(globalindices(prototype_θφ, 2))
-        local_φ_range = first(φ_globals):last(φ_globals)
+        local_φ_range = _owned_range(φ_globals)
         Vtθφ = Vtθφ_local[:, local_φ_range]
         Vpθφ = Vpθφ_local[:, local_φ_range]
         if !real_output
@@ -1368,15 +1430,26 @@ function _dist_synthesis_sphtor_with_scratch!(cfg::SHTnsKit.SHTConfig, Slm::Abst
                 tblNP  = cfg.NP_tables[col]
                 tblNdP = cfg.NdP_tables[col]
 
+                # sinθ == 0 at an exact pole node (pole-inclusive regular/DH grids):
+                # the tables hold the guarded 0 there, not the true limit, so reading
+                # them would silently zero the entire m=1 contribution on those rows.
+                # Use the closed forms the serial kernels use (src/kernels.jl).
+                is_pole = sθ < SHTnsKit.POLE_TOLERANCE_FACTOR * eps(Float64)
                 @inbounds for l in max(1, mval):lmax
-                    dθY = -sθ * tblNdP[l+1, iglobθ]
-                    Y   = tblNP[l+1, iglobθ]
+                    if is_pole
+                        N = cfg.Nlm[l+1, col]
+                        dθY       = SHTnsKit._dPdtheta_at_pole(l, mval, x, N)
+                        Y_over_sθ = SHTnsKit._P_over_sinth_at_pole(l, mval, x, N)
+                    else
+                        dθY       = -sθ * tblNdP[l+1, iglobθ]
+                        Y_over_sθ = tblNP[l+1, iglobθ] * inv_sθ
+                    end
                     Sl = Slm[l+1, col]
                     Tl = Tlm[l+1, col]
                     # Vθ = ∂S/∂θ - (im/sinθ) * T
-                    gθ += dθY * Sl - (0 + 1im) * mval * inv_sθ * Y * Tl
+                    gθ += dθY * Sl - (0 + 1im) * mval * Y_over_sθ * Tl
                     # Vφ = (im/sinθ) * S + ∂T/∂θ
-                    gφ += (0 + 1im) * mval * inv_sθ * Y * Sl + dθY * Tl
+                    gφ += (0 + 1im) * mval * Y_over_sθ * Sl + dθY * Tl
                 end
             else
                 # OTF: normalized rows — P̄, dP̄/dθ, P̄/sinθ; no extra Nlm multiply.
@@ -1431,7 +1504,7 @@ function _dist_synthesis_sphtor_with_scratch!(cfg::SHTnsKit.SHTConfig, Slm::Abst
         copyto!(parent(Vpθφ_out), Vpθφ_local)
     else
         φ_globals = collect(globalindices(prototype_θφ, 2))
-        local_φ_range = first(φ_globals):last(φ_globals)
+        local_φ_range = _owned_range(φ_globals)
         copyto!(parent(Vtθφ_out), view(Vtθφ_local, :, local_φ_range))
         copyto!(parent(Vpθφ_out), view(Vpθφ_local, :, local_φ_range))
     end
@@ -1828,8 +1901,8 @@ function dist_analysis_distributed(cfg::SHTnsKit.SHTConfig, fθφ::PencilArray;
         SHTnsKitParallelExt.fft_along_dim2!(Fθm, local_data)
     else
         φ_globals = collect(globalindices(fθφ, 2))
-        φ_range = first(φ_globals):last(φ_globals)
-        θ_range = first(θ_globals):last(θ_globals)
+        φ_range = _owned_range(φ_globals)
+        θ_range = _owned_range(θ_globals)
         Fθm = _gather_and_fft_phi(local_data, θ_range, φ_range, nlon, comm)
     end
 
@@ -2609,8 +2682,8 @@ function _dist_analysis_2d_safe(cfg::SHTnsKit.SHTConfig, fθφ::PencilArray;
         SHTnsKitParallelExt.fft_along_dim2!(Fθm, local_data)
     else
         φ_globals = collect(globalindices(fθφ, 2))
-        φ_range = first(φ_globals):last(φ_globals)
-        θ_range = first(θ_globals):last(θ_globals)
+        φ_range = _owned_range(φ_globals)
+        θ_range = _owned_range(θ_globals)
         Fθm = _gather_and_fft_phi(local_data, θ_range, φ_range, nlon, comm)
     end
 
@@ -2900,7 +2973,7 @@ function dist_synthesis_distributed_2d_optimized(cfg::SHTnsKit.SHTConfig, alm::D
         end
     else
         φ_globals = collect(globalindices(prototype_θφ, 2))
-        local_φ_range = first(φ_globals):last(φ_globals)
+        local_φ_range = _owned_range(φ_globals)
         result = fθφ_local[:, local_φ_range]
         if !real_output
             result = Complex{Float64}.(result)
@@ -3038,8 +3111,8 @@ function _dist_analysis_2d_aligned(cfg::SHTnsKit.SHTConfig, fθφ::PencilArray;
         SHTnsKitParallelExt.fft_along_dim2!(Fθm, local_data)
     else
         φ_globals = collect(globalindices(fθφ, 2))
-        φ_range = first(φ_globals):last(φ_globals)
-        θ_range = first(θ_globals):last(θ_globals)
+        φ_range = _owned_range(φ_globals)
+        θ_range = _owned_range(θ_globals)
         Fθm_temp = _gather_and_fft_phi(local_data, θ_range, φ_range, nlon, plan.comm)
         copyto!(Fθm, Fθm_temp)
     end

--- a/ext/SHTnsKitParallelADExt.jl
+++ b/ext/SHTnsKitParallelADExt.jl
@@ -211,8 +211,11 @@ function ChainRulesCore.rrule(::typeof(SHTnsKit.dist_synthesis_sphtor),
         # One batched Allreduce over stacked (S̄,T̄) instead of two round-trips.
         n = length(S̄p)
         combined = MPI.Allreduce!(vcat(vec(S̄p), vec(T̄p)), +, comm)
-        S̄ = reshape(combined[1:n], size(S̄p))
-        T̄ = reshape(combined[n+1:end], size(T̄p))
+        # `reshape(view(...))` instead of `combined[1:n]`: range indexing copies in
+        # Julia, so the slice form allocated two more full-size arrays on top of the
+        # vcat (~12 MB per backward pass at lmax=511).
+        S̄ = reshape(view(combined, 1:n), size(S̄p))
+        T̄ = reshape(view(combined, (n+1):length(combined)), size(T̄p))
         return NoTangent(), NoTangent(), S̄, T̄
     end
     return y, dist_synthesis_sphtor_pullback

--- a/ext/SHTnsKitParallelExt.jl
+++ b/ext/SHTnsKitParallelExt.jl
@@ -136,8 +136,7 @@ struct _ParallelExtState
     cache_enabled::Base.RefValue{Bool}                  # toggle plan caching
     pfft_cache::IdDict{Any,Any}                         # FFT plan cache (keyed by shape/type/comm)
     pfft_cache_max::Base.RefValue{Int}                  # soft cap on pfft_cache entries
-    cache_lock::Threads.ReentrantLock                   # guards pfft_cache + sparse_gather_cache
-    sparse_gather_cache::Dict{Any, NamedTuple{(:idx,:val),Tuple{Vector{Int},Any}}}
+    cache_lock::Threads.ReentrantLock                   # guards pfft_cache
     fftw_cache_lock::Threads.ReentrantLock              # guards local-FFTW plan caches
 end
 
@@ -146,7 +145,6 @@ const _STATE = _ParallelExtState(
     IdDict{Any,Any}(),
     Ref{Int}(parse(Int, get(ENV, "SHTNSKIT_PFFT_CACHE_MAX", "64"))),
     Threads.ReentrantLock(),
-    Dict{Any, NamedTuple{(:idx,:val),Tuple{Vector{Int},Any}}}(),
     Threads.ReentrantLock(),
 )
 
@@ -155,7 +153,6 @@ const _CACHE_PENCILFFTS    = _STATE.cache_enabled
 const _pfft_cache          = _STATE.pfft_cache
 const _PFFT_CACHE_MAX      = _STATE.pfft_cache_max
 const _cache_lock          = _STATE.cache_lock
-const _sparse_gather_cache = _STATE.sparse_gather_cache
 
 """
     pfft_cache_max!(n::Int) -> Int
@@ -935,15 +932,15 @@ include("ParallelRotationsPencil.jl") # Parallel spherical rotation operations
 include("ParallelLocal.jl")            # Local (per-process) operations and utilities
 include("ParallelTransposeTransforms.jl")  # Transpose-based distributed SHT (Task 2+)
 
-# Optimized communication patterns for large spectral arrays
-# A plain Allreduce is the correct primitive for summing spectral partials over θ:
-# a tuned MPI already performs topology-aware (hierarchical) reduction internally.
-# The former `adaptive_spectral_communication!` route selected
-# `hierarchical_spectral_reduce!`, which wraps the SAME `Allreduce!` in TWO per-call
-# `MPI.Comm_split` collectives (`tree_reduce!` is literally `Allreduce!`) for zero
-# algorithmic gain — strictly slower on the hot analysis/sphtor path. Call Allreduce
-# directly. (`adaptive_spectral_communication!` is retained for callers that opt into
-# the sparse/segmented strategies explicitly.)
+# Reduction of spectral partials over θ.
+# A plain Allreduce is the correct primitive here: a tuned MPI already performs
+# topology-aware (hierarchical) reduction internally. This used to route through
+# `adaptive_spectral_communication!` → `hierarchical_spectral_reduce!`, which wraps
+# the SAME `Allreduce!` in TWO per-call `MPI.Comm_split` collectives (`tree_reduce!`
+# was literally `Allreduce!`) for zero algorithmic gain — strictly slower on the hot
+# analysis/sphtor path. That whole adaptive/sparse/segmented/hierarchical tree has
+# been deleted rather than left unreachable; recover it from git history if a real
+# use case for the sparse or segmented strategies ever appears.
 function efficient_spectral_reduce!(local_data::AbstractMatrix, comm)
     MPI.Allreduce!(local_data, +, comm)
     return local_data
@@ -952,303 +949,6 @@ end
 function efficient_spectral_reduce!(local_data::AbstractVector, comm)
     MPI.Allreduce!(local_data, +, comm)
     return local_data
-end
-
-function hierarchical_spectral_reduce!(local_data::AbstractMatrix, comm, ppn::Int)
-    rank = MPI.Comm_rank(comm)
-    nprocs = MPI.Comm_size(comm)
-    
-    # Level 1: Intra-node reduction (shared memory optimization)
-    node_id = rank ÷ ppn
-    local_rank = rank % ppn
-    
-    # Create intra-node communicator for shared-memory optimization
-    node_comm = MPI.Comm_split(comm, node_id, local_rank)
-    node_nprocs = MPI.Comm_size(node_comm)
-    
-    if node_nprocs > 1
-        # Reduce within each compute node using optimized shared-memory path
-        MPI.Allreduce!(local_data, +, node_comm)
-    end
-    
-    # Level 2: Inter-node reduction (network-aware)
-    if local_rank == 0  # Node representatives
-        inter_node_comm = MPI.Comm_split(comm, 0, node_id)
-        inter_nprocs = MPI.Comm_size(inter_node_comm)
-        
-        if inter_nprocs > 1
-            # Use tree-based reduction between nodes for network efficiency
-            tree_reduce!(local_data, inter_node_comm)
-        end
-        
-        _safe_comm_free(inter_node_comm)
-    else
-        # Create dummy communicator for non-representatives and free it
-        dummy_comm = MPI.Comm_split(comm, 1, 0)
-        _safe_comm_free(dummy_comm)
-    end
-
-    # Level 3: Broadcast results back within nodes
-    if node_nprocs > 1
-        MPI.Bcast!(local_data, 0, node_comm)
-    end
-    
-    _safe_comm_free(node_comm)
-end
-
-function tree_reduce!(data::AbstractMatrix, comm)
-    # Use MPI.Allreduce! which is correct for all process counts
-    MPI.Allreduce!(data, +, comm)
-end
-
-function sparse_spectral_reduce!(local_data::AbstractVector{T}, comm) where {T}
-    # True sparse reduction using Allgatherv of (indices, values)
-    nz_idx = findall(!iszero, local_data)
-    send_count = length(nz_idx)
-
-    # Gather counts to all ranks and build displacements
-    counts = Allgather(send_count, comm)
-    displs = cumsum([0; counts[1:end-1]])
-    total = sum(counts)
-
-    # Prepare send buffers
-    idx_send = collect(Int, nz_idx)
-    val_send = local_data[nz_idx]
-
-    # Receive buffers (reused across calls when possible)
-    # Note: Resize operations are performed outside the lock to reduce contention.
-    # This is safe because each (T, comm) key maps to a unique buffer pair that
-    # is only used by operations on that specific communicator.
-    key = (T, MPI.Comm_rank(comm), MPI.Comm_size(comm))
-    idx_recv, val_recv = lock(_cache_lock) do
-        if haskey(_sparse_gather_cache, key)
-            buf = _sparse_gather_cache[key]
-            idx_buf = buf.idx
-            val_buf = buf.val
-            if length(idx_buf) < total
-                resize!(idx_buf, total)
-            end
-            if length(val_buf) < total
-                resize!(val_buf, total)
-            end
-            (idx_buf, val_buf)
-        else
-            idx_buf = Vector{Int}(undef, total)
-            val_buf = Vector{T}(undef, total)
-            _sparse_gather_cache[key] = (idx=idx_buf, val=val_buf)
-            (idx_buf, val_buf)
-        end
-    end
-
-    # Exchange indices and values using MPI.jl v0.20+ API
-    Allgatherv!(idx_send, VBuffer(idx_recv, counts), comm)
-    Allgatherv!(val_send, VBuffer(val_recv, counts), comm)
-
-    # Accumulate into the full dense vector
-    fill!(local_data, zero(T))
-    @inbounds for i in 1:total
-        local_data[idx_recv[i]] += val_recv[i]
-    end
-    return local_data
-end
-
-function sparse_spectral_reduce!(local_data::AbstractMatrix{T}, comm) where {T}
-    # Flattened sparse reduction on matrix storage
-    A = vec(local_data)
-    sparse_spectral_reduce!(A, comm)
-    return local_data
-end
-
-# ===== ADVANCED COMMUNICATION PATTERNS =====
-
-"""
-    adaptive_spectral_communication!(data, comm; operation, sparse_threshold=0.1)
-
-Adaptive communication pattern that automatically chooses the optimal strategy
-based on data sparsity and process count for spherical harmonic coefficients.
-
-Strategies:
-- Dense data + few processes: Standard Allreduce
-- Dense data + many processes: Hierarchical reduction  
-- Sparse data: Sparse coefficient exchange
-- Very large data: Segmented reduction with overlap
-"""
-function adaptive_spectral_communication!(data::AbstractArray, comm; operation=+, sparse_threshold=nothing)
-    nprocs = MPI.Comm_size(comm)
-    data_size = length(data)
-    # Resolve sparsity threshold from ENV if not provided
-    st = sparse_threshold === nothing ? try parse(Float64, get(ENV, "SHTNSKIT_SPARSE_THRESHOLD", "0.1")) catch; 0.1 end : sparse_threshold
-    
-    # Compute sparsity ratio. CRITICAL: the branch below selects an MPI collective
-    # sequence, so the decision MUST be identical on every rank. A per-rank local
-    # sparsity diverges (each rank owns a different zero-pattern) → ranks take
-    # different branches → mismatched collectives → deadlock. Decide it GLOBALLY.
-    local_nz = count(!iszero, data)
-    gathered = MPI.Allreduce!(Float64[local_nz, data_size], +, comm)
-    sparsity = gathered[1] / gathered[2]
-
-    # NOTE: sparse_spectral_reduce! and hierarchical_spectral_reduce! are sum-only
-    # (they never consumed `operation`); gate them on `operation === +` so a
-    # non-additive reduction falls through to a general collective instead of
-    # silently being summed. segmented_spectral_reduce! and Allreduce! honor it.
-    if operation === (+) && sparsity < st && data_size > 1000
-        # Use sparse communication for very sparse data (robust fallback)
-        return sparse_spectral_reduce!(data, comm)
-    elseif nprocs > 64 && data_size > 50000
-        # Use segmented reduction for large-scale problems
-        return segmented_spectral_reduce!(data, comm, operation)
-    elseif operation === (+) && nprocs > 16 && data_size > 5000
-        # Use hierarchical reduction for medium-scale problems
-        if isa(data, AbstractMatrix)
-            return hierarchical_spectral_reduce!(data, comm, min(nprocs, 32))
-        else
-            return hierarchical_spectral_reduce_vector!(data, comm, min(nprocs, 32))
-        end
-    else
-        # Use standard Allreduce for small problems
-        MPI.Allreduce!(data, operation, comm)
-        return data
-    end
-end
-
-"""
-    segmented_spectral_reduce!(data, comm, operation)
-
-Segmented reduction for very large spectral arrays that don't fit in memory.
-Processes data in chunks with communication/computation overlap.
-"""
-function segmented_spectral_reduce!(data::AbstractArray, comm, operation)
-    nprocs = MPI.Comm_size(comm)
-    rank = MPI.Comm_rank(comm)
-    
-    # Determine optimal segment size based on available memory
-    max_segment_mb = parse(Int, get(ENV, "SHTNSKIT_MAX_SEGMENT_MB", "128"))
-    bytes_per_element = sizeof(eltype(data))
-    max_elements_per_segment = (max_segment_mb * 1024 * 1024) ÷ bytes_per_element
-    
-    segment_size = min(length(data), max_elements_per_segment)
-    num_segments = (length(data) + segment_size - 1) ÷ segment_size
-    
-    # Process segments with overlapped communication (double-buffered)
-    temp_a = similar(data, segment_size)
-    temp_b = similar(data, segment_size)
-    prev_req = nothing
-    prev_buf = nothing  # :a or :b
-    prev_len = 0
-    prev_start = 0
-
-    try
-        for seg in 1:num_segments
-            start_idx = (seg - 1) * segment_size + 1
-            end_idx = min(seg * segment_size, length(data))
-            segment_data = view(data, start_idx:end_idx)
-            cur_len = length(segment_data)
-
-            # Choose buffer not in use by previous outstanding request
-            buf_sym = (prev_buf == :a) ? :b : :a
-            temp_view = buf_sym === :a ? view(temp_a, 1:cur_len) : view(temp_b, 1:cur_len)
-            copyto!(temp_view, segment_data)
-
-            # Launch nonblocking reduction for current segment
-            req = MPI.Iallreduce!(temp_view, operation, comm)
-
-            # Complete previous request and write back
-            if prev_req !== nothing
-                MPI.Wait(prev_req)
-                pstart = prev_start
-                pend = min(pstart + prev_len - 1, length(data))
-                prev_data = view(data, pstart:pend)
-                prev_view = (prev_buf === :a ? view(temp_a, 1:prev_len) : view(temp_b, 1:prev_len))
-                copyto!(prev_data, prev_view)
-            end
-
-            # Promote current to previous
-            prev_req = req
-            prev_buf = buf_sym
-            prev_len = cur_len
-            prev_start = start_idx
-        end
-
-        # Final pending segment
-        if prev_req !== nothing
-            MPI.Wait(prev_req)
-            prev_req = nothing
-            pstart = prev_start
-            pend = min(pstart + prev_len - 1, length(data))
-            prev_data = view(data, pstart:pend)
-            prev_view = (prev_buf === :a ? view(temp_a, 1:prev_len) : view(temp_b, 1:prev_len))
-            copyto!(prev_data, prev_view)
-        end
-    finally
-        # Drain any outstanding request so MPI doesn't retain buffer refs on error paths.
-        if prev_req !== nothing
-            try MPI.Wait(prev_req) catch end
-        end
-    end
-
-    return data
-end
-
-"""
-    hierarchical_spectral_reduce_vector!(data, comm, ppn)
-
-Vector-specialized hierarchical reduction with optimized memory access patterns.
-"""
-function hierarchical_spectral_reduce_vector!(data::AbstractVector, comm, ppn::Int)
-    rank = MPI.Comm_rank(comm)
-    nprocs = MPI.Comm_size(comm)
-    
-    # Create node-local communicator
-    node_id = rank ÷ ppn
-    local_rank = rank % ppn
-    node_comm = MPI.Comm_split(comm, node_id, local_rank)
-    node_nprocs = MPI.Comm_size(node_comm)
-    
-    # Intra-node reduction with memory-friendly chunking
-    if node_nprocs > 1
-        chunk_size = min(length(data), 10000)  # Process in chunks for cache efficiency
-        
-        for start_idx in 1:chunk_size:length(data)
-            end_idx = min(start_idx + chunk_size - 1, length(data))
-            chunk_view = view(data, start_idx:end_idx)
-            MPI.Allreduce!(chunk_view, +, node_comm)
-        end
-    end
-    
-    # Inter-node reduction (only node leaders participate)
-    if local_rank == 0
-        inter_node_comm = MPI.Comm_split(comm, 0, node_id)
-        inter_nprocs = MPI.Comm_size(inter_node_comm)
-        
-        if inter_nprocs > 1
-            # Use tree reduction for better network scaling
-            tree_reduce_vector!(data, inter_node_comm)
-        end
-        
-        _safe_comm_free(inter_node_comm)
-    else
-        # Non-leaders create dummy communicator and free it
-        dummy_comm = MPI.Comm_split(comm, 1, 0)
-        _safe_comm_free(dummy_comm)
-    end
-
-    # Broadcast results within nodes
-    if node_nprocs > 1
-        MPI.Bcast!(data, 0, node_comm)
-    end
-    
-    _safe_comm_free(node_comm)
-    return data
-end
-
-"""
-    tree_reduce_vector!(data, comm)
-
-Binary tree reduction optimized for vector data with better memory locality.
-"""
-function tree_reduce_vector!(data::AbstractVector, comm)
-    # Use MPI.Allreduce! which is correct for all process counts
-    MPI.Allreduce!(data, +, comm)
 end
 
 """

--- a/src/api_compat.jl
+++ b/src/api_compat.jl
@@ -40,10 +40,23 @@ _grid_symbol(code::Int) = code == SHT_GAUSS ? :gauss :
 _min_nlat_for_grid(code::Int, lmax::Int) = code == SHT_REGULAR_POLES ? (lmax + 1) :
                                            (code == SHT_REGULAR || code == SHT_REG_FAST || code == SHT_QUICK_INIT ? (lmax + 2) : (lmax + 1))
 
+"""
+    _parse_phase_bits(f::Int) -> (cs_phase, real_norm)
+
+Decode the phase/normalization option bits shared by `shtns_create`,
+`shtns_init` and `shtns_set_grid`. These live in the high bits, orthogonal to
+the grid-type low byte, so every entry point that takes a flag word must apply
+them — otherwise a caller passing `SHT_NO_CS_PHASE` silently gets the default.
+"""
+function _parse_phase_bits(f::Int)
+    cs_phase = (f & SHT_NO_CS_PHASE) == 0
+    real_norm = (f & SHT_REAL_NORM) != 0
+    return cs_phase, real_norm
+end
+
 function _parse_norm_bits(nval::Int)
     base_norm = nval % 256
-    cs_phase = (nval & SHT_NO_CS_PHASE) == 0
-    real_norm = (nval & SHT_REAL_NORM) != 0
+    cs_phase, real_norm = _parse_phase_bits(nval)
     nsym = base_norm == 0 ? :orthonormal : base_norm == 1 ? :fourpi : base_norm == 2 ? :schmidt : :orthonormal
     return nsym, cs_phase, real_norm
 end
@@ -103,8 +116,7 @@ function shtns_init(flags::Integer, lmax::Integer, mmax::Integer, mres::Integer,
     # Honor the documented norm/CS-phase flags (higher bits, orthogonal to the
     # grid-type low byte). Previously these were silently ignored, so a caller
     # passing SHT_NO_CS_PHASE / SHT_REAL_NORM got a default-normalized config.
-    cs_phase = (f & SHT_NO_CS_PHASE) == 0
-    real_norm = (f & SHT_REAL_NORM) != 0
+    cs_phase, real_norm = _parse_phase_bits(f)
 
     cfg = if grid_sym == :gauss
         if use_on_the_fly
@@ -149,6 +161,7 @@ function shtns_set_grid(cfg::SHTConfig, flags::Integer, eps::Real, nlat::Integer
     grid_type = f % 256
     south_pole_first = (f & SHT_SOUTH_POLE_FIRST) != 0
     allow_padding = (f & SHT_ALLOW_PADDING) != 0
+    cs_phase, real_norm = _parse_phase_bits(f)
     grid_sym = _grid_symbol(grid_type)
     min_lat = _min_nlat_for_grid(grid_type, cfg.lmax)
     nlat = max(Int(nlat), min_lat)
@@ -193,7 +206,13 @@ function shtns_set_grid(cfg::SHTConfig, flags::Integer, eps::Real, nlat::Integer
     cfg.st = sin.(θ)
     cfg.nspat = nlat * nphi
     cfg.cphi = 2π / nphi
-  
+
+    # Same high-bit options `shtns_init` honors — this entry point used to drop
+    # them, so `shtns_create` + `shtns_set_grid(..., SHT_NO_CS_PHASE, ...)` kept
+    # the default Condon-Shortley phase. Set before prepare_plm_tables! below.
+    cfg.cs_phase = cs_phase
+    cfg.real_norm = real_norm
+
     # Reset south_pole_first before reconfiguring
     cfg.south_pole_first = false
 

--- a/src/loop.jl
+++ b/src/loop.jl
@@ -172,22 +172,29 @@ for both CPU and GPU paths, and dispatches based on the array backend at runtime
 - CPU path uses @simd @fastmath @inbounds for vectorization
 - Set `SHTnsKit.set_loop_backend("SIMD")` to force CPU path
 
-!!! warning
-    Operands must be **plain variables**, not field accesses. A `getfield`
-    expression in the body (e.g. `cfg.scale`) is rewritten to the bare field
-    symbol (`scale`) when captured as a kernel argument, which does not exist in
-    the caller's scope (`UndefVarError`). Bind such values to locals first:
-    `s = cfg.scale; @sht_loop dest[i] = s * src[i] over i ∈ 1:n`.
+Field accesses in the body (e.g. `cfg.scale`) are supported: the *expression* is
+evaluated once at the call site and passed in under a hygienic name, so it can
+never pick up an unrelated caller local that happens to share the field name.
 """
 macro sht_loop(args...)
     ex, _, itr = args
     _, I, R = itr.args
-    sym = Symbol[]
-    grab!(sym, ex)                          # Extract all symbols from expression
-    setdiff!(sym, _loop_index_symbols(I))   # Don't pass loop indices as arguments
+    idx = _loop_index_symbols(I)            # loop indices are bound by the kernel, not passed in
+    ops = Any[]
+    _grab_ops!(ops, ex, idx)                # operand expressions, in first-use order
+    isempty(ops) && throw(ArgumentError("@sht_loop: loop body references no operands"))
 
-    symT = [gensym() for _ in 1:length(sym)]  # Generate type parameters
-    symWtypes = joinsymtype(rep.(sym), symT)  # Symbols with types: [a::A, b::B, ...]
+    # Plain variables keep their own name (the quote is `esc`aped, so the kernel
+    # argument resolves to the caller's binding). A field access gets a gensym
+    # instead and is passed *as the original expression*: rewriting `cfg.scale` to
+    # the bare symbol `scale` would silently bind to any caller local of that name
+    # — names like `w`, `x`, `scale`, `norm` are everywhere in transform code — and
+    # multiply by the wrong value with no error.
+    names = Symbol[op isa Symbol ? op : gensym(_field_name(op)) for op in ops]
+    body = _subst_ops(ex, ops, names)
+
+    symT = [gensym() for _ in 1:length(names)]  # Generate type parameters
+    symWtypes = joinsymtype(names, symT)        # Symbols with types: [a::A, b::B, ...]
 
     @gensym kern_cpu dispatch_kern
 
@@ -195,34 +202,34 @@ macro sht_loop(args...)
         # CPU path: SIMD loop
         function $kern_cpu($(symWtypes...), R) where {$(symT...)}
             @simd for $I ∈ R
-                @fastmath @inbounds $ex
+                @fastmath @inbounds $body
             end
         end
 
         # Dispatch function: choose backend based on array type
         function $dispatch_kern($(symWtypes...), R) where {$(symT...)}
-            first_arr = $(sym[1])
+            first_arr = $(names[1])
 
             # Check for PencilArray (MPI-distributed) - always use CPU SIMD on local data
             if $_is_pencil_array(first_arr)
                 # For PencilArrays, get local data and run SIMD
                 # Note: Caller must handle MPI communication separately
-                $kern_cpu($(sym...), R)
+                $kern_cpu($(names...), R)
             elseif $_LOOP_BACKEND[] == "SIMD" || $_is_cpu_array(first_arr)
                 # Regular CPU array - use SIMD
-                $kern_cpu($(sym...), R)
+                $kern_cpu($(names...), R)
             elseif $_GPU_LOOP_AVAILABLE[]
                 # GPU array - use GPU extension's kernel launcher
-                $_GPU_KERNEL_LAUNCHER[]($(sym...), R, $I -> $ex)
+                $_GPU_KERNEL_LAUNCHER[]($(names...), R, $I -> $body)
             else
                 # GPU array but extension not loaded - fall back to CPU
                 @warn "GPU array detected but GPU extension not loaded. Using CPU fallback." maxlog=1
-                $kern_cpu($(sym...), R)
+                $kern_cpu($(names...), R)
             end
         end
 
-        # Call the dispatcher
-        $dispatch_kern($(sym...), $R)
+        # Call the dispatcher — field accesses are evaluated HERE, in the caller
+        $dispatch_kern($(ops...), $R)
     end |> esc
 end
 
@@ -254,39 +261,64 @@ function _loop_index_symbols(I)
 end
 
 """
-    grab!(sym, ex)
+    _is_field_access(ex) -> Bool
 
-Recursively extract all symbols and composite names from expression `ex`,
-adding them to the `sym` array. Also replaces composite expressions with
-their simplified symbol forms.
+True for a literal `a.b` getproperty node. Deliberately excludes broadcast
+syntax (`f.(x)`), which shares the `:.` head but carries a tuple, not a
+`QuoteNode`, in `args[2]`.
 """
-function grab!(sym::Vector{Symbol}, ex::Expr)
-    # Grab composite name (e.g., a.b) and return
-    if ex.head == :.
-        push!(sym, Symbol(ex.args[2].value))
-        return
+_is_field_access(ex::Expr) = ex.head === :. && length(ex.args) == 2 && ex.args[2] isa QuoteNode
+_is_field_access(ex) = false
+
+_field_name(ex::Expr) = Symbol(ex.args[2].value)
+
+"""
+    _grab_ops!(ops, ex, idx)
+
+Collect the operand expressions of a loop body into `ops`, in first-use order and
+without duplicates: plain variables as `Symbol`s, field accesses as the whole
+`a.b` expression. Loop indices (`idx`) and callee names are skipped.
+"""
+function _grab_ops!(ops::Vector{Any}, ex::Expr, idx::Vector{Symbol})
+    if _is_field_access(ex)
+        ex in ops || push!(ops, ex)
+        return ops
     end
     # Don't grab function names in calls
     start = ex.head == :call ? 2 : 1
-    # Recurse into arguments
-    foreach(a -> grab!(sym, a), ex.args[start:end])
-    # Replace composites in args
-    ex.args[start:end] = rep.(ex.args[start:end])
+    for a in ex.args[start:end]
+        _grab_ops!(ops, a, idx)
+    end
+    return ops
 end
 
-function grab!(sym::Vector{Symbol}, ex::Symbol)
-    push!(sym, ex)
+function _grab_ops!(ops::Vector{Any}, ex::Symbol, idx::Vector{Symbol})
+    (ex in idx || ex in ops) || push!(ops, ex)
+    return ops
 end
 
-grab!(sym::Vector{Symbol}, ex) = nothing  # Ignore literals, etc.
+_grab_ops!(ops::Vector{Any}, ex, idx::Vector{Symbol}) = ops  # Ignore literals, etc.
 
 """
-    rep(ex)
+    _subst_ops(ex, ops, names) -> expr
 
-Replace composite expressions (like `a.b`) with just the field symbol.
+Rewrite the loop body so each operand is referred to by its kernel-argument name.
+Plain variables map to themselves; a field access maps to its hygienic gensym.
 """
-rep(ex) = ex
-rep(ex::Expr) = ex.head == :. ? Symbol(ex.args[2].value) : ex
+function _subst_ops(ex::Expr, ops::Vector{Any}, names::Vector{Symbol})
+    if _is_field_access(ex)
+        i = findfirst(==(ex), ops)
+        return i === nothing ? ex : names[i]
+    end
+    return Expr(ex.head, map(a -> _subst_ops(a, ops, names), ex.args)...)
+end
+
+function _subst_ops(ex::Symbol, ops::Vector{Any}, names::Vector{Symbol})
+    i = findfirst(==(ex), ops)
+    return i === nothing ? ex : names[i]
+end
+
+_subst_ops(ex, ops::Vector{Any}, names::Vector{Symbol}) = ex
 
 """
     joinsymtype(sym, symT)

--- a/test/parallel/runtests.jl
+++ b/test/parallel/runtests.jl
@@ -12,6 +12,7 @@
 # - test_transpose_sht.jl      : DistTransposePlan transforms, canonical grid (mpiexec)
 # - test_disttranspose_dealiased.jl : DistTransposePlan on dealiased nlon>2*mmax+1 (mpiexec)
 # - test_dist_plan_alloc.jl    : DistAnalysisPlan correctness + per-call allocation budget (mpiexec)
+# - test_mpi_audit_fixes.jl    : Regressions for the 2026-08 distributed audit fixes (mpiexec)
 #
 # To run MPI tests:
 #   mpiexec -n 4 julia --project test/parallel/test_mpi_comprehensive.jl
@@ -19,6 +20,7 @@
 #   mpiexec -n 2 julia --project test/parallel/test_transpose_sht.jl
 #   mpiexec -n 2 julia --project test/parallel/test_disttranspose_dealiased.jl
 #   mpiexec -n 2 julia --project test/parallel/test_dist_plan_alloc.jl
+#   mpiexec -n 4 julia --project test/parallel/test_mpi_audit_fixes.jl
 
 using Test
 

--- a/test/parallel/test_mpi_audit_fixes.jl
+++ b/test/parallel/test_mpi_audit_fixes.jl
@@ -1,0 +1,215 @@
+#!/usr/bin/env julia
+#
+# MPI regression tests for the distributed defects found in the 2026-08 audit.
+# Each testset pins one fix; every one of them either crashed, hung, or returned
+# silently wrong numbers before.
+#
+#   1. dist_analysis_packed_cplx: LM_cplx negative-m rule (no (-1)^m) + complex input
+#   2. packed storage: accumulation/normalization loops must stride by mres
+#   3. sphtor table kernels: closed-form pole limits instead of the guarded 0
+#   4. ranks owning zero φ columns (nranks > nlon) must not crash the φ gather
+#   5. 2D (θ×φ) pencil: θ-slab reduction must not over-count φ-partners
+#
+# Run with: mpiexec -n 4 julia --project test/parallel/test_mpi_audit_fixes.jl
+
+using MPI
+MPI.Init()
+
+using Test
+using Random
+using PencilArrays
+using PencilFFTs
+using SHTnsKit
+
+const ParExt = Base.get_extension(SHTnsKit, :SHTnsKitParallelExt)
+const comm = MPI.COMM_WORLD
+const rank = MPI.Comm_rank(comm)
+const nprocs = MPI.Comm_size(comm)
+
+root_println(args...) = (rank == 0 && (println(args...); flush(stdout)))
+
+"""Scatter a globally-known matrix into the local block of `pen`."""
+function scatter_field(pen::Pencil, F::AbstractMatrix)
+    r = PencilArrays.range_local(pen)
+    loc = Array{eltype(F)}(undef, length(r[1]), length(r[2]))
+    for (jl, jg) in enumerate(r[2]), (il, ig) in enumerate(r[1])
+        loc[il, jl] = F[ig, jg]
+    end
+    return PencilArray(pen, loc)
+end
+
+"""Max |local - F| over the rank's block of `pen`, reduced over all ranks."""
+function max_local_error(local_block::AbstractMatrix, F::AbstractMatrix, pen::Pencil)
+    r = PencilArrays.range_local(pen)
+    err = 0.0
+    for (jl, jg) in enumerate(r[2]), (il, ig) in enumerate(r[1])
+        err = max(err, abs(local_block[il, jl] - F[ig, jg]))
+    end
+    return MPI.Allreduce(err, max, comm)
+end
+
+max_local_error(pa::PencilArray, F::AbstractMatrix) =
+    max_local_error(parent(pa), F, pencil(pa))
+
+@testset "MPI audit-fix regressions ($nprocs ranks)" begin
+
+    @testset "dist_analysis_packed_cplx LM_cplx layout" begin
+        lmax = 5
+        nlat, nlon = lmax + 2, 2*lmax + 1
+        cfg = create_gauss_config(lmax, nlat; nlon=nlon)
+        rng = MersenneTwister(20260807)
+        pen = Pencil((nlat, nlon), (1,), comm)   # θ decomposition
+
+        # Real field: the −m half is conj(a_{+m}) with NO (-1)^m. The old code's
+        # (-1)^m flipped every odd-m coefficient.
+        F = randn(rng, nlat, nlon)
+        got = SHTnsKit.dist_analysis_packed_cplx(cfg, scatter_field(pen, F))
+        ref = SHTnsKit.analysis_packed_cplx(cfg, complex.(F))
+        @test isapprox(got, ref; rtol=1e-9, atol=1e-11)
+
+        # Genuinely complex field (independent ±m): the old code fabricated the
+        # −m half from the +m half and silently returned a symmetrized spectrum.
+        Z = randn(rng, ComplexF64, nlat, nlon)
+        gotc = SHTnsKit.dist_analysis_packed_cplx(cfg, scatter_field(pen, Z))
+        refc = SHTnsKit.analysis_packed_cplx(cfg, Z)
+        @test isapprox(gotc, refc; rtol=1e-9, atol=1e-11)
+        @test !isapprox(gotc, got; rtol=1e-3)   # sanity: the two inputs differ
+
+        # mres > 1 has no LM_cplx layout — fail loudly instead of mis-indexing.
+        cfg2 = create_gauss_config(lmax, nlat; mmax=lmax, mres=2, nlon=nlon)
+        @test_throws ArgumentError SHTnsKit.dist_analysis_packed_cplx(cfg2, scatter_field(pen, F))
+        root_println("    [PASS] LM_cplx packed analysis")
+    end
+
+    @testset "packed storage strides by mres" begin
+        lmax = mmax = 6
+        mres = 2
+        nlat, nlon = lmax + 2, max(2*mmax + 1, 4)
+        # :fourpi also exercises the packed norm-conversion loop, which wrote
+        # Alm_local[0] under @inbounds for every m that is not a multiple of mres.
+        cfg = create_gauss_config(lmax, nlat; mmax=mmax, mres=mres, nlon=nlon, norm=:fourpi)
+        rng = MersenneTwister(4242)
+        F = randn(rng, nlat, nlon)
+        pen = Pencil((nlat, nlon), (1,), comm)
+        fpa = scatter_field(pen, F)
+
+        packed = SHTnsKit.dist_analysis(cfg, fpa; use_packed_storage=true)
+        dense = SHTnsKit.dist_analysis(cfg, fpa)
+        info = ParExt.create_packed_storage_info(cfg)
+        @test length(packed) == info.nlm_packed
+        maxerr = 0.0
+        for m in 0:mres:mmax, l in m:lmax
+            maxerr = max(maxerr, abs(packed[info.lm_to_packed[l+1, m+1]] - dense[l+1, m+1]))
+        end
+        @test maxerr < 1e-11
+        root_println("    [PASS] packed storage with mres=$mres")
+    end
+
+    @testset "sphtor pole limits on a pole-inclusive grid" begin
+        lmax = 6
+        nlat, nlon = lmax + 2, 2*lmax + 1
+        cfg = create_regular_config(lmax, nlat; nlon=nlon, include_poles=true,
+                                    precompute_plm=true)
+        @test cfg.use_plm_tables                       # the table kernels are live
+        @test minimum(abs.(1.0 .- abs.(cfg.x))) == 0.0 # grid really includes ±1
+
+        rng = MersenneTwister(99)
+        Slm = zeros(ComplexF64, lmax+1, cfg.mmax+1)
+        Tlm = zeros(ComplexF64, lmax+1, cfg.mmax+1)
+        for m in 0:cfg.mmax, l in max(1, m):lmax
+            Slm[l+1, m+1] = randn(rng, ComplexF64)
+            Tlm[l+1, m+1] = randn(rng, ComplexF64)
+        end
+        Slm[:, 1] .= real.(Slm[:, 1]); Tlm[:, 1] .= real.(Tlm[:, 1])
+
+        # Serial reference uses the closed-form pole branch (src/kernels.jl).
+        Vt, Vp = SHTnsKit.synthesis_sphtor(cfg, Slm, Tlm; real_output=true)
+        @test maximum(abs, Vt) > 1e-6                  # non-trivial reference
+
+        pen = Pencil((nlat, nlon), (1,), comm)
+        proto = scatter_field(pen, Vt)
+        Vt_d, Vp_d = SHTnsKit.dist_synthesis_sphtor(cfg, Slm, Tlm;
+                                                    prototype_θφ=proto, real_output=true)
+        # Before the fix the θ=0 and θ=π rows came back 0 from the table path.
+        @test max_local_error(Vt_d, Vt, pen) < 1e-9
+        @test max_local_error(Vp_d, Vp, pen) < 1e-9
+
+        # Analysis direction reads the same tables.
+        Sref, Tref = SHTnsKit.analysis_sphtor(cfg, Vt, Vp)
+        S_d, T_d = SHTnsKit.dist_analysis_sphtor(cfg, scatter_field(pen, Vt),
+                                                 scatter_field(pen, Vp))
+        @test isapprox(S_d, Sref; rtol=1e-8, atol=1e-10)
+        @test isapprox(T_d, Tref; rtol=1e-8, atol=1e-10)
+        root_println("    [PASS] sphtor pole limits")
+    end
+
+    @testset "rank owning zero φ columns" begin
+        lmax = mmax = 1
+        nlat, nlon = 3, 3
+        if nprocs <= nlon
+            root_println("    [SKIP] zero-φ rank needs nprocs > nlon=$nlon")
+        else
+            cfg = create_gauss_config(lmax, nlat; mmax=mmax, nlon=nlon)
+            rng = MersenneTwister(11)
+            F = randn(rng, nlat, nlon)
+            pen = Pencil((nlat, nlon), comm)   # decomposes φ → last ranks own nothing
+            fpa = scatter_field(pen, F)
+            # Used to BoundsError on the empty rank while its partners blocked in
+            # the gather collective, hanging the job.
+            alm = SHTnsKit.dist_analysis(cfg, fpa)
+            @test isapprox(alm, SHTnsKit.analysis(cfg, F); rtol=1e-9, atol=1e-11)
+            root_println("    [PASS] zero-φ rank")
+        end
+    end
+
+    @testset "2D (θ×φ) pencil reduction" begin
+        lmax = 6
+        nlat, nlon = lmax + 2, 2*lmax + 1
+        cfg = create_gauss_config(lmax, nlat; nlon=nlon)
+        pen2 = try
+            Pencil((nlat, nlon), (1, 2), comm)
+        catch err
+            root_println("    [SKIP] 2D pencil unsupported here: ", err)
+            nothing
+        end
+        if pen2 === nothing
+            @test true
+        else
+            r = PencilArrays.range_local(pen2)
+            both_split = MPI.Allreduce(
+                (length(r[1]) < nlat && length(r[2]) < nlon) ? 1 : 0, +, comm) == nprocs
+            if !both_split
+                root_println("    [SKIP] topology did not split both dims")
+                @test true
+            else
+                rng = MersenneTwister(2026)
+                F = randn(rng, nlat, nlon)
+                fpa = scatter_field(pen2, F)
+                # φ-partners of a θ-slab hold identical partials; over-counting
+                # them scaled the whole spectrum by the φ-partition factor.
+                @test isapprox(SHTnsKit.dist_analysis(cfg, fpa),
+                               SHTnsKit.analysis(cfg, F); rtol=1e-9, atol=1e-11)
+
+                Slm = zeros(ComplexF64, lmax+1, cfg.mmax+1)
+                Tlm = zeros(ComplexF64, lmax+1, cfg.mmax+1)
+                for m in 0:cfg.mmax, l in max(1, m):lmax
+                    Slm[l+1, m+1] = randn(rng, ComplexF64)
+                    Tlm[l+1, m+1] = randn(rng, ComplexF64)
+                end
+                Slm[:, 1] .= real.(Slm[:, 1]); Tlm[:, 1] .= real.(Tlm[:, 1])
+                Vt, Vp = SHTnsKit.synthesis_sphtor(cfg, Slm, Tlm; real_output=true)
+                Sref, Tref = SHTnsKit.analysis_sphtor(cfg, Vt, Vp)
+                # This path used to Comm_split on first([]) with no guard at all.
+                S_d, T_d = SHTnsKit.dist_analysis_sphtor(cfg, scatter_field(pen2, Vt),
+                                                         scatter_field(pen2, Vp))
+                @test isapprox(S_d, Sref; rtol=1e-8, atol=1e-10)
+                @test isapprox(T_d, Tref; rtol=1e-8, atol=1e-10)
+                root_println("    [PASS] 2D pencil reduction")
+            end
+        end
+    end
+end
+
+MPI.Barrier(comm)
+root_println("\nAll MPI audit-fix regression tests PASSED")
+MPI.Finalize()

--- a/test/serial/test_api_compat.jl
+++ b/test/serial/test_api_compat.jl
@@ -89,6 +89,27 @@ using SHTnsKit
         @test cfg.grid_type == :regular_poles
     end
 
+    @testset "shtns_set_grid honors phase/norm flags" begin
+        # shtns_set_grid parses the same flag word as shtns_init and must apply
+        # the high-bit options too; it used to extract only SOUTH_POLE_FIRST and
+        # ALLOW_PADDING, so the C-API sequence create + set_grid silently kept the
+        # default Condon-Shortley phase.
+        lmax, mmax = 5, 5
+        cfg = shtns_create(lmax, mmax, 1, 0)
+        @test cfg.cs_phase == true
+        @test cfg.real_norm == false
+
+        @test shtns_set_grid(cfg, SHT_GAUSS | SHT_NO_CS_PHASE | SHT_REAL_NORM,
+                             1e-10, lmax + 3, 2*mmax + 3) == 0
+        @test cfg.cs_phase == false
+        @test cfg.real_norm == true
+
+        # And back off again — the flags are read fresh on every call.
+        @test shtns_set_grid(cfg, SHT_GAUSS, 1e-10, lmax + 3, 2*mmax + 3) == 0
+        @test cfg.cs_phase == true
+        @test cfg.real_norm == false
+    end
+
     @testset "shtns_create parses norm bits" begin
         # base_norm=2 → schmidt; NO_CS_PHASE flag disables CS; REAL_NORM flag sets real_norm
         flags = 2 | SHT_NO_CS_PHASE | SHT_REAL_NORM

--- a/test/serial/test_complex_packed.jl
+++ b/test/serial/test_complex_packed.jl
@@ -100,6 +100,49 @@ using SHTnsKit
         @test isapprox(alm_back, alm; rtol=1e-10, atol=1e-12)
     end
 
+    @testset "LM_cplx negative-m rule for real fields" begin
+        # This layout uses P̄_l^{|m|} for BOTH signs of m, so a real field's
+        # Hermitian relation is a_{l,-m} = conj(a_{l,m}) with NO (-1)^m factor
+        # (that factor belongs to the Y_l^m convention). Pin it: the distributed
+        # `dist_analysis_packed_cplx` builds its −m half from exactly this rule.
+        lmax = 5
+        nlat = lmax + 2
+        nlon = 2*lmax + 1
+        cfg = create_gauss_config(lmax, nlat; nlon=nlon)
+        rng = MersenneTwister(20260807)
+        f = randn(rng, nlat, nlon)
+
+        alm = analysis(cfg, f)                       # m ≥ 0 half
+        alm_c = analysis_packed_cplx(cfg, complex.(f))
+        for l in 0:lmax, m in 1:min(l, cfg.mmax)
+            ip = LM_cplx_index(lmax, cfg.mmax, l, m) + 1
+            im_ = LM_cplx_index(lmax, cfg.mmax, l, -m) + 1
+            @test isapprox(alm_c[ip], alm[l+1, m+1]; rtol=1e-10, atol=1e-12)
+            @test isapprox(alm_c[im_], conj(alm[l+1, m+1]); rtol=1e-10, atol=1e-12)
+        end
+
+        # Filling the −m half with conj(a) reproduces the field; the (-1)^m
+        # variant does not (and is not even real).
+        packed = Vector{ComplexF64}(undef, SHTnsKit.nlm_cplx_calc(lmax, cfg.mmax, 1))
+        wrong = similar(packed)
+        for l in 0:lmax
+            packed[LM_cplx_index(lmax, cfg.mmax, l, 0) + 1] = alm[l+1, 1]
+            wrong[LM_cplx_index(lmax, cfg.mmax, l, 0) + 1] = alm[l+1, 1]
+            for m in 1:min(l, cfg.mmax)
+                ap = alm[l+1, m+1]
+                packed[LM_cplx_index(lmax, cfg.mmax, l, m) + 1] = ap
+                packed[LM_cplx_index(lmax, cfg.mmax, l, -m) + 1] = conj(ap)
+                wrong[LM_cplx_index(lmax, cfg.mmax, l, m) + 1] = ap
+                wrong[LM_cplx_index(lmax, cfg.mmax, l, -m) + 1] = ((-1)^m) * conj(ap)
+            end
+        end
+        z = synthesis_packed_cplx(cfg, packed)
+        @test isapprox(z, complex.(synthesis(cfg, alm; real_output=true)); rtol=1e-10, atol=1e-12)
+        @test maximum(abs, imag.(z)) < 1e-12
+        zw = synthesis_packed_cplx(cfg, wrong)
+        @test !isapprox(zw, z; rtol=1e-6, atol=1e-8)
+    end
+
     @testset "Packed to matrix conversion" begin
         lmax = 5
         nlat = lmax + 2

--- a/test/serial/test_loop_utils.jl
+++ b/test/serial/test_loop_utils.jl
@@ -111,4 +111,31 @@ using SHTnsKit
         SHTnsKit.@sht_loop dest[I] = src[I] over I ∈ CartesianIndices(dest)
         @test dest ≈ src
     end
+
+    @testset "@sht_loop field-access hygiene" begin
+        # A field access in the body must read THAT field, never an unrelated
+        # caller local of the same name. Rewriting `cfg.scale` to the bare symbol
+        # `scale` used to silently pick up the local below and compile cleanly.
+        holder = (scale = 3.0,)
+        scale = -100.0          # decoy: same name, wrong value
+        dest = zeros(6)
+        src = collect(1.0:6.0)
+        SHTnsKit.@sht_loop dest[i] = holder.scale * src[i] over i ∈ 1:6
+        @test dest ≈ 3.0 .* src
+        @test scale == -100.0   # untouched
+
+        # Same field name reached through two different objects in one body.
+        a = (w = 2.0,)
+        b = (w = 5.0,)
+        out = zeros(4)
+        ones4 = ones(4)
+        SHTnsKit.@sht_loop out[i] = a.w * ones4[i] + b.w over i ∈ 1:4
+        @test out ≈ fill(7.0, 4)
+
+        # Repeated operands must not produce duplicate kernel argument names.
+        d2 = zeros(5)
+        s2 = collect(1.0:5.0)
+        SHTnsKit.@sht_loop d2[i] = s2[i] + s2[i] over i ∈ 1:5
+        @test d2 ≈ 2 .* s2
+    end
 end


### PR DESCRIPTION
## What this is

Three rounds of auditing this package, one after another. Each round reviewed
the code, found real bugs, fixed them, and added tests. The third round
reviewed the first two, which is where most of the interesting findings came
from.

27 files changed. Everything here is verified — see "How this was checked" at
the bottom.

## Round 1 — correctness, AD, type stability, MPI efficiency (546c30a)

- Distributed AD called `globalindices` / `communicator`, which are defined in
  a sibling extension module and not exported by PencilArrays, so the first
  call hit an `UndefVarError`.
- Three separate MPI deadlocks: a collective chosen from rank-local data, a
  validation error thrown on only some ranks, and a `first([])` on a rank that
  owns no longitude columns.
- Legendre tables came out full of `NaN` on grids that include the poles,
  because of a division by `sin(theta) = 0`.
- Every packed rotation gradient (Z, Y, Y90, X90) was wrong. The correct
  adjoint for the standard inner product is `Q = W R^-1 (W^-1 y)` with
  `W = diag(wm)`, `wm = 2` for `m > 0`; the code used a different form.
- `synthesis_batch`'s gradient used `analysis` as the adjoint of synthesis.
  Those differ by the Gauss weights.
- Several accumulators hardcoded `ComplexF64`, which breaks `Float32` and
  breaks ForwardDiff (`Dual` can't convert to `Float64`).
- The "hierarchical" MPI reduction wrapped the same `Allreduce!` in two extra
  communicator splits per call, for no gain.

## Round 2 — pole tables (6c41878)

Round 1's pole fix turned precomputed tables off completely on pole-inclusive
grids, which regressed a config that asks for them. Only the derivative table
needs a guard — the value table has no division by `sin(theta)` and is correct
at the poles — so tables stay on and only the division is guarded.

## Round 3 — reviewing rounds 1 and 2 (d431ef5)

Ten more problems. The pattern worth naming: several round-1 fixes stopped the
code from crashing but left it quietly returning wrong numbers. That is worse,
because nothing tells you anything happened.

**Wrong results**

- The negative-m coefficients in `dist_analysis_packed_cplx` were filled with
  `(-1)^m * conj(a)`. That factor belongs to a different convention. Here both
  `+m` and `-m` use the same Legendre row `P(l,|m|)`, so the right value is
  just `conj(a)`. Every odd-m coefficient had its sign flipped. The function
  now also handles genuinely complex input properly instead of pretending the
  input was real.
- The packed-storage loops walked every `m`, but the packed index table only
  has entries for multiples of `mres` — everything else is `0`. Under
  `@inbounds`, with `mres > 1`, that wrote to element 0 of the buffer.
- On pole-inclusive grids the derivative table stores a guarded `0` (see round
  2). The serial kernels know that and switch to a closed-form limit at the
  poles; the three distributed sphtor kernels did not, so the entire `m = 1`
  contribution on the two pole rows came back as zero.

**Crashes and hangs with many MPI ranks**

- A rank can legitimately own zero longitude columns (say `nlon = 4` on 5
  ranks). Building its range as `first(x):last(x)` threw on that rank while
  every other rank was already waiting inside the gather, so the job hung. All
  18 of these are now guarded.
- The vector analysis path still split the communicator on `first(x)` of the
  same possibly-empty list, so it kept exactly the crash the scalar path had
  just been guarded against.

  Both paths now share one helper. On a 2-D pencil, every rank sharing a theta
  slab holds the same partial result, because the gather already handed each of
  them the full longitude. So rather than grouping ranks by their phi position,
  we group by theta, keep one rank per slab, zero the rest, and do a plain
  full-communicator sum. Simpler, exact, and it also fixes a case the old
  grouping got wrong: with more than one empty phi partition, those ranks
  shared a fallback group and their slabs got counted twice.

**A macro that could read the wrong variable**

`@sht_loop` rewrote `cfg.w` into the bare name `w` and passed that to the
generated kernel. If the caller had its own local named `w`, the macro compiled
cleanly and used the wrong value — and `w`, `x`, `scale`, `norm` are everywhere
in this code. It now passes the original expression at the call site and binds
it to a unique generated name inside the kernel.

**Smaller items**

- `shtns_set_grid` reads the same flag word as `shtns_init` but only looked at
  two of the flags, so `shtns_create` + `shtns_set_grid(..., SHT_NO_CS_PHASE,
  ...)` silently kept the default phase.
- Deleted 297 lines of reduction code that had no callers left, plus the
  process-wide cache it kept alive.
- A gradient path used `combined[1:n]`, which copies in Julia, allocating two
  extra full-size arrays. Switched to `reshape(view(...))`.

## How this was checked

| Suite | Result |
| --- | --- |
| Serial tests | 67262 / 0 failures |
| Parallel grid tests | 1673 / 0 failures |
| MPI: comprehensive, extended, transpose, dealiased, plan_alloc, audit-fixes | all green on 2, 4 and 6 ranks |
| Distributed sphtor gradient vs finite differences | relative error 6.9e-11 |
| Aqua | passes |

New tests added along the way: rotation gradients vs finite differences (24
checks), batch AD adjoints, and a new MPI file covering the five distributed
fixes from round 3 — packed complex layout, `mres > 1` packed storage, sphtor on
a pole grid, a rank with zero longitude columns, and a 2-D pencil. Plus serial
tests for the macro name capture, the `shtns_set_grid` flags, and the
negative-m rule.

## Note

Some tracked `.DS_Store` files are deleted in the working tree but not included
here. Say the word and I'll add that as a separate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
