### PR TITLE
Fix MPI empty-partition hangs, sphtor OTF pole limits, and shtns_set_grid clobber

### DIFF
--- a/ext/ParallelLocal.jl
+++ b/ext/ParallelLocal.jl
@@ -277,13 +277,29 @@ function SHTnsKit.dist_analysis_packed_cplx(cfg::SHTnsKit.SHTConfig, z::PencilAr
     # There is NO (-1)^m: this LM_cplx layout uses the SAME P̄_l^{|m|} row for both
     # signs of m (see `synthesis_packed_cplx` / `SH_to_lat_cplx`), unlike the
     # Y_l^m convention where the Hermitian relation carries that factor.
-    Aplus = SHTnsKit.dist_analysis(cfg, z; use_tables=cfg.use_plm_tables)
-    Aminus = if eltype(z) <: Real
-        Aplus                       # conj(z) == z — reuse instead of a second transform
+    #
+    # A complex field is split into its real and imaginary parts rather than fed
+    # to `dist_analysis` directly: analysis is ℂ-linear in the field, so the two
+    # real transforms give BOTH halves at once —
+    #     A(z) = A(Re z) + i·A(Im z),   A(conj z) = A(Re z) − i·A(Im z)
+    # — and, unlike a complex PencilArray, real data survives the φ-gather path
+    # (`_gather_phi_rows` packs into a `Vector{Float64}`, so a ComplexF64 array on
+    # a φ-decomposed pencil threw `InexactError` on every rank). A single-pass
+    # variant that kept the ±m φ-FFT bins `dist_analysis` discards would halve
+    # this again; that needs a distributed analysis returning both halves.
+    Aplus, Aminus = if eltype(z) <: Real
+        A = SHTnsKit.dist_analysis(cfg, z; use_tables=cfg.use_plm_tables)
+        A, A                        # conj(z) == z — one transform covers both
     else
-        zc = similar(z)
-        parent(zc) .= conj.(parent(z))
-        SHTnsKit.dist_analysis(cfg, zc; use_tables=cfg.use_plm_tables)
+        RT = real(eltype(z))
+        pen = pencil(z)
+        zr = PencilArray{RT}(undef, pen)
+        zi = PencilArray{RT}(undef, pen)
+        parent(zr) .= real.(parent(z))
+        parent(zi) .= imag.(parent(z))
+        Ar = SHTnsKit.dist_analysis(cfg, zr; use_tables=cfg.use_plm_tables)
+        Ai = SHTnsKit.dist_analysis(cfg, zi; use_tables=cfg.use_plm_tables)
+        (Ar .+ im .* Ai), (Ar .- im .* Ai)
     end
     alm_p = Vector{ComplexF64}(undef, SHTnsKit.nlm_cplx_calc(lmax, mmax, 1))
     for l in 0:lmax

--- a/ext/ParallelPlans.jl
+++ b/ext/ParallelPlans.jl
@@ -76,8 +76,8 @@ function DistAnalysisPlan(cfg::SHTnsKit.SHTConfig, prototype_θφ::PencilArray; 
     reduce_comm = if θ_is_distributed && !fallback_standard
         # Reduce only across ranks sharing this φ-segment (see
         # dist_analysis_standard STEP 5 for the 2D-pencil rationale).
-        φ_globals = globalindices(prototype_θφ, 2)
-        MPI.Comm_split(comm, Int(first(φ_globals)), MPI.Comm_rank(comm))
+        φ_globals = collect(Int, globalindices(prototype_θφ, 2))
+        MPI.Comm_split(comm, _phi_column_color(φ_globals), MPI.Comm_rank(comm))
     else
         comm
     end
@@ -176,8 +176,8 @@ function DistSphtorPlan(cfg::SHTnsKit.SHTConfig, prototype_θφ::PencilArray; wi
     Tlm_work = Matrix{ComplexF64}(undef, lmax + 1, cfg.mmax + 1)
     θ_is_distributed = nθ_local < cfg.nlat
     reduce_comm = if θ_is_distributed && !fallback_standard
-        φ_globals = globalindices(prototype_θφ, 2)
-        MPI.Comm_split(comm, Int(first(φ_globals)), MPI.Comm_rank(comm))
+        φ_globals = collect(Int, globalindices(prototype_θφ, 2))
+        MPI.Comm_split(comm, _phi_column_color(φ_globals), MPI.Comm_rank(comm))
     else
         comm
     end

--- a/ext/ParallelTransforms.jl
+++ b/ext/ParallelTransforms.jl
@@ -229,7 +229,24 @@ already expect: `length == 0` contributes a zero-count `Allgatherv` segment.
 _owned_range(globals) = isempty(globals) ? (1:0) : (Int(first(globals)):Int(last(globals)))
 
 """
-    _keep_one_phi_partner!(comm, θ_first, arrays...)
+    _phi_column_color(φ_globals) -> Int
+
+`MPI.Comm_split` colour that groups the ranks of one θ-column — those sharing a
+φ-segment — so a 2D (θ×φ) pencil sums each θ-slab once rather than once per
+φ-partner. The colour is the first global φ index the rank owns.
+
+A rank owning zero φ columns has no segment of its own, and the raw
+`first(φ_globals)` throws a BoundsError there — killing that rank while its
+partners are already blocked inside `Comm_split`/`Allreduce!`, so the job hangs
+instead of failing. Such a rank is folded into the column that owns global φ
+index 1: its spatial contribution is all-zero so it cannot perturb that column's
+sum, and in exchange it receives the complete θ-summed spectrum, which it still
+needs for whatever spectral coefficients it owns.
+"""
+_phi_column_color(φ_globals) = isempty(φ_globals) ? 1 : Int(first(φ_globals))
+
+"""
+    _keep_one_phi_partner!(φ_globals, arrays...)
 
 Prepare θ-slab partials for a plain full-comm reduction on a 2D (θ×φ) pencil.
 
@@ -238,22 +255,31 @@ already handed each of them the full longitude), so reducing over the full comm
 would count each slab once per φ-partition. Zeroing all but one partner per
 θ-slab makes the subsequent full-comm sum count each slab exactly once.
 
-This replaces splitting the comm by φ-colour, which had no correct colour for a
-rank owning zero φ columns: `first([])` crashed it, and lumping such ranks under
-a shared colour silently over-counted whenever more than one φ-partition was
-empty. Grouping by θ instead is always well defined — `first` of an empty θ range
-is still a number — and the result is bit-identical to the exact θ-slab sum.
+The keeper is picked *locally*, with no collective at all: on a (pθ × pφ) pencil
+the φ-partitions tile `1:nlon`, so every θ-slab has exactly one φ-partner that
+owns global φ index 1. A rank owning zero φ columns is never that partner, and
+its partial is dropped like any other non-keeper.
+
+Two earlier forms of this are wrong, and both are avoided here:
+
+  * splitting the comm by φ-colour had no correct colour for a rank owning zero
+    φ columns — `first([])` crashed it, and a shared colour for all such ranks
+    over-counted whenever more than one φ-partition was empty;
+  * splitting by *θ*-colour looks safe (`first(1:0)` is still a number) but a
+    rank owning zero θ rows collides with the genuine owner of global θ index 1,
+    and `Comm_split` orders by global rank — so the empty rank can win rank 0 of
+    the group and zero the real θ=1 slab out of the sum entirely.
+
+Dropping the split also removes a synchronizing collective (plus a communicator
+allocate/free) from every 2D-pencil analysis call. The subsequent reduction is
+over the full comm rather than a θ-column subcomm: broader, but the subcomm can
+only be obtained from the very `Comm_split` this avoids, and it is the cheaper
+half of that trade on the hot path.
 """
-function _keep_one_phi_partner!(comm, θ_first::Int, arrays::Vararg{AbstractArray})
-    row_comm = MPI.Comm_split(comm, θ_first, MPI.Comm_rank(comm))
-    try
-        if MPI.Comm_rank(row_comm) != 0
-            for A in arrays
-                fill!(A, zero(eltype(A)))
-            end
-        end
-    finally
-        SHTnsKitParallelExt._safe_comm_free(row_comm)
+function _keep_one_phi_partner!(φ_globals, arrays::Vararg{AbstractArray})
+    (!isempty(φ_globals) && Int(first(φ_globals)) == 1) && return nothing
+    for A in arrays
+        fill!(A, zero(eltype(A)))
     end
     return nothing
 end
@@ -633,13 +659,12 @@ Decompose latitude instead: `SHTnsKit.create_spatial_pencil(cfg; comm)` or `Penc
         # φ-partition factor. Drop all but one partner per θ-slab first.
         if nlon_local == nlon
             # θ-only decomposition: φ is complete on every rank, so there are no
-            # φ-partners to dedup. Reduce directly and skip the per-call
-            # MPI.Comm_split (a synchronizing collective) entirely.
+            # φ-partners to dedup. Reduce directly.
             SHTnsKitParallelExt.efficient_spectral_reduce!(Alm_local, comm)
         else
             # 2D (θ×φ) pencil: keep one partner per θ-slab, then reduce over the
             # full comm so each slab is summed exactly once.
-            _keep_one_phi_partner!(comm, first(_owned_range(θ_globals)), Alm_local)
+            _keep_one_phi_partner!(collect(Int, globalindices(fθφ, 2)), Alm_local)
             SHTnsKitParallelExt.efficient_spectral_reduce!(Alm_local, comm)
         end
         if !use_packed_storage
@@ -1003,9 +1028,9 @@ function SHTnsKit.dist_analysis_sphtor(cfg::SHTnsKit.SHTConfig, Vtθφ::PencilAr
     # path uses (concrete argument types; the previous inline loop boxed its
     # way to ~2.9 MB/call).
     if use_tbl
-        _sphtor_analysis_loop_tbl!(Slm_local, Tlm_local, cfg.NP_tables, cfg.NdP_tables,
-                                   Ftθm, Fpθm, θ_globals, x_cache, sθ_cache, inv_sθ_cache,
-                                   weights_cache, cfg.Nlm, cfg.robert_form, scaleφ, lmax, mmax)
+        _sphtor_analysis_loop_tbl!(cfg, Slm_local, Tlm_local, cfg.NP_tables, cfg.NdP_tables,
+                                   Ftθm, Fpθm, θ_globals, sθ_cache,
+                                   weights_cache, cfg.robert_form, scaleφ, lmax, mmax)
     else
         _sphtor_analysis_loop_otf!(Slm_local, Tlm_local, P, dPdtheta, P_over_sth, Pbuf,
                                    Ftθm, Fpθm, x_cache, sθ_cache, inv_sθ_cache,
@@ -1021,11 +1046,11 @@ function SHTnsKit.dist_analysis_sphtor(cfg::SHTnsKit.SHTConfig, Vtθφ::PencilAr
         # there for the rationale): on a 2D (θ×φ) pencil the φ-partners of a
         # θ-slab hold identical partials, so keep one per slab before summing.
         if nlon_local == nlon
-            # θ-only decomposition: no φ-partners, so skip the MPI.Comm_split.
+            # θ-only decomposition: no φ-partners to dedup.
             SHTnsKitParallelExt.efficient_spectral_reduce!(Slm_local, comm)
             SHTnsKitParallelExt.efficient_spectral_reduce!(Tlm_local, comm)
         else
-            _keep_one_phi_partner!(comm, first(_owned_range(θ_globals)), Slm_local, Tlm_local)
+            _keep_one_phi_partner!(collect(Int, globalindices(Vtθφ, 2)), Slm_local, Tlm_local)
             SHTnsKitParallelExt.efficient_spectral_reduce!(Slm_local, comm)
             SHTnsKitParallelExt.efficient_spectral_reduce!(Tlm_local, comm)
         end
@@ -1045,23 +1070,24 @@ end
 # Function barriers for the sphtor analysis accumulation (see the scalar
 # _analysis_loop_* barriers for the rationale: concrete argument types keep the
 # m/θ/l loops allocation-free).
-function _sphtor_analysis_loop_tbl!(Slm::Matrix{ComplexF64}, Tlm::Matrix{ComplexF64},
+function _sphtor_analysis_loop_tbl!(cfg::SHTnsKit.SHTConfig,
+                                    Slm::Matrix{ComplexF64}, Tlm::Matrix{ComplexF64},
                                     NP_tables::Vector{Matrix{Float64}}, NdP_tables::Vector{Matrix{Float64}},
                                     Ftθm::Matrix{ComplexF64}, Fpθm::Matrix{ComplexF64},
-                                    θ_globals::Vector{Int}, x_cache::Vector{Float64},
-                                    sθ_cache::Vector{Float64},
-                                    inv_sθ_cache::Vector{Float64}, weights_cache::Vector{Float64},
-                                    Nlm::Matrix{Float64},
+                                    θ_globals::Vector{Int},
+                                    sθ_cache::Vector{Float64}, weights_cache::Vector{Float64},
                                     robert_form::Bool, scaleφ::Float64, lmax::Int, mmax::Int)
     nθ_local = length(θ_globals)
     for mval in 0:mmax
         col = mval + 1
         tblNP  = NP_tables[col]
         tblNdP = NdP_tables[col]
+        # Accumulate straight into the m-column (unique per m → race-free, AD-safe).
+        Sacc = view(Slm, :, col)
+        Tacc = view(Tlm, :, col)
         for ii in 1:nθ_local
             iglobθ = θ_globals[ii]
             sθ = sθ_cache[ii]
-            inv_sθ = inv_sθ_cache[ii]
             wi = weights_cache[ii]
             Fθ_i = Ftθm[ii, col]
             Fφ_i = Fpθm[ii, col]
@@ -1069,27 +1095,13 @@ function _sphtor_analysis_loop_tbl!(Slm::Matrix{ComplexF64}, Tlm::Matrix{Complex
                 Fθ_i /= sθ
                 Fφ_i /= sθ
             end
-            # At an exact pole node (pole-inclusive regular/DH grids) sinθ == 0, so
-            # the stored tables carry the guarded 0 rather than the true limit —
-            # reading them there would silently zero the whole m=1 contribution.
-            # Use the same closed forms the serial kernels use (src/kernels.jl).
-            xi = x_cache[ii]
-            is_pole = sθ < SHTnsKit.POLE_TOLERANCE_FACTOR * eps(Float64)
-            @inbounds for l in max(1, mval):lmax
-                if is_pole
-                    N = Nlm[l+1, col]
-                    dθY       = SHTnsKit._dPdtheta_at_pole(l, mval, xi, N)
-                    Y_over_sθ = SHTnsKit._P_over_sinth_at_pole(l, mval, xi, N)
-                else
-                    dθY       = -sθ * tblNdP[l+1, iglobθ]
-                    Y_over_sθ = tblNP[l+1, iglobθ] * inv_sθ
-                end
-                coeff = wi * scaleφ / (l * (l + 1))
-                term = (0 + 1im) * mval * Y_over_sθ
-                # Adjoint of synthesis: Vθ = dθY*S - term*T, Vφ = term*S + dθY*T
-                Slm[l+1, col] += coeff * (Fθ_i * dθY + conj(term) * Fφ_i)
-                Tlm[l+1, col] += coeff * (-conj(term) * Fθ_i + dθY * Fφ_i)
-            end
+            # Shared serial kernel rather than a fourth hand-copy of the pole
+            # branch: at an exact pole node (pole-inclusive regular/DH grids)
+            # sinθ == 0 and the stored tables carry the guarded 0 rather than the
+            # true limit, so the kernel swaps in the closed forms. `iglobθ` is the
+            # cfg-global latitude index both cfg.x and the tables are keyed on.
+            SHTnsKit._sphtor_analysis_kernel!(Sacc, Tacc, cfg, Fθ_i, Fφ_i, wi,
+                                              tblNP, tblNdP, iglobθ, col, mval, lmax, scaleφ)
         end
     end
     return nothing
@@ -1166,10 +1178,10 @@ function SHTnsKit.dist_analysis_sphtor!(plan::DistSphtorPlan, Slm_out::AbstractM
     use_tbl = use_tables && cfg.use_plm_tables && !isempty(cfg.NP_tables) && !isempty(cfg.NdP_tables) &&
               length(cfg.NP_tables) == mmax + 1 && length(cfg.NdP_tables) == mmax + 1
     if use_tbl
-        _sphtor_analysis_loop_tbl!(plan.Slm_work, plan.Tlm_work, cfg.NP_tables, cfg.NdP_tables,
-                                   plan.Ftθm, plan.Fpθm, plan.θ_globals, plan.x_cache,
-                                   plan.sθ_cache, plan.inv_sθ_cache, plan.weights_cache,
-                                   cfg.Nlm, cfg.robert_form, cfg.cphi, lmax, mmax)
+        _sphtor_analysis_loop_tbl!(cfg, plan.Slm_work, plan.Tlm_work, cfg.NP_tables, cfg.NdP_tables,
+                                   plan.Ftθm, plan.Fpθm, plan.θ_globals,
+                                   plan.sθ_cache, plan.weights_cache,
+                                   cfg.robert_form, cfg.cphi, lmax, mmax)
     else
         _sphtor_analysis_loop_otf!(plan.Slm_work, plan.Tlm_work, plan.P, plan.dPdtheta,
                                    plan.P_over_sth, plan.Pbuf, plan.Ftθm, plan.Fpθm,
@@ -1241,53 +1253,23 @@ function SHTnsKit.dist_synthesis_sphtor(cfg::SHTnsKit.SHTConfig, Slm::AbstractMa
         col = mval + 1
 
         for (ii, iglobθ) in enumerate(θ_globals)
-            x = xv[iglobθ]
-            sθ = sqrt(max(0.0, 1 - x * x))
-            inv_sθ = sθ == 0 ? 0.0 : 1.0 / sθ
-
-            gθ = 0.0 + 0.0im
-            gφ = 0.0 + 0.0im
-
-            if cfg.use_plm_tables && !isempty(cfg.NP_tables) && !isempty(cfg.NdP_tables)
-                # NP_tables: P̄ already; NdP_tables: -dP̄/dθ/sinθ already.
-                tblNP  = cfg.NP_tables[col]
-                tblNdP = cfg.NdP_tables[col]
-
-                # sinθ == 0 at an exact pole node (pole-inclusive regular/DH grids):
-                # the tables hold the guarded 0 there, not the true limit, so reading
-                # them would silently zero the entire m=1 contribution on those rows.
-                # Use the closed forms the serial kernels use (src/kernels.jl).
-                is_pole = sθ < SHTnsKit.POLE_TOLERANCE_FACTOR * eps(Float64)
-                @inbounds for l in max(1, mval):lmax
-                    if is_pole
-                        N = cfg.Nlm[l+1, col]
-                        dθY       = SHTnsKit._dPdtheta_at_pole(l, mval, x, N)
-                        Y_over_sθ = SHTnsKit._P_over_sinth_at_pole(l, mval, x, N)
-                    else
-                        dθY       = -sθ * tblNdP[l+1, iglobθ]
-                        Y_over_sθ = tblNP[l+1, iglobθ] * inv_sθ
-                    end
-                    Sl = Slm[l+1, col]
-                    Tl = Tlm[l+1, col]
-                    # Vθ = ∂S/∂θ - (im/sinθ) * T
-                    gθ += dθY * Sl - (0 + 1im) * mval * Y_over_sθ * Tl
-                    # Vφ = (im/sinθ) * S + ∂T/∂θ
-                    gφ += (0 + 1im) * mval * Y_over_sθ * Sl + dθY * Tl
-                end
+            # Shared serial kernels (src/kernels.jl) rather than a third and fourth
+            # inlining of the table/OTF split. Both branches need pole handling the
+            # inline copies got wrong or only half-right:
+            #   * tables hold the guarded 0 at an exact pole node (pole-inclusive
+            #     regular/DH grids, sinθ == 0), not the true limit, so the kernel
+            #     substitutes the closed forms there;
+            #   * OTF must read the pole-safe P̄/sinθ row, NOT P̄ * (1/sinθ) — that
+            #     product is 0 at a pole because inv_sθ is guarded to 0, silently
+            #     dropping the entire m=1 contribution from the pole rows.
+            # `iglobθ` is the cfg-global latitude index cfg.x and the tables share.
+            gθ, gφ = if cfg.use_plm_tables && !isempty(cfg.NP_tables) && !isempty(cfg.NdP_tables)
+                SHTnsKit._sphtor_synthesis_kernel(cfg, Slm, Tlm,
+                                                  cfg.NP_tables[col], cfg.NdP_tables[col],
+                                                  iglobθ, col, mval, lmax)
             else
-                # OTF: normalized rows — P̄, dP̄/dθ, P̄/sinθ; no extra Nlm multiply.
-                SHTnsKit.Plm_norm_dPdtheta_over_sinth_row!(P, dPdtheta, P_over_sth, x, lmax, mval, Pbuf)
-
-                @inbounds for l in max(1, mval):lmax
-                    dθY = dPdtheta[l+1]    # dP̄/dθ already orthonormal-normalized
-                    Y   = P[l+1]           # P̄
-                    Sl = Slm[l+1, col]
-                    Tl = Tlm[l+1, col]
-                    # Vθ = ∂S/∂θ - (im/sinθ) * T
-                    gθ += dθY * Sl - (0 + 1im) * mval * inv_sθ * Y * Tl
-                    # Vφ = (im/sinθ) * S + ∂T/∂θ
-                    gφ += (0 + 1im) * mval * inv_sθ * Y * Sl + dθY * Tl
-                end
+                SHTnsKit._sphtor_synthesis_kernel_otf(cfg, Slm, Tlm, P, dPdtheta, P_over_sth,
+                                                      Pbuf, iglobθ, col, mval, lmax)
             end
 
             # Store Fourier coefficient
@@ -1418,53 +1400,23 @@ function _dist_synthesis_sphtor_with_scratch!(cfg::SHTnsKit.SHTConfig, Slm::Abst
         col = mval + 1
 
         for (ii, iglobθ) in enumerate(θ_globals)
-            x = xv[iglobθ]
-            sθ = sqrt(max(0.0, 1 - x * x))
-            inv_sθ = sθ == 0 ? 0.0 : 1.0 / sθ
-
-            gθ = 0.0 + 0.0im
-            gφ = 0.0 + 0.0im
-
-            if cfg.use_plm_tables && !isempty(cfg.NP_tables) && !isempty(cfg.NdP_tables)
-                # NP_tables: P̄ already; NdP_tables: -dP̄/dθ/sinθ already.
-                tblNP  = cfg.NP_tables[col]
-                tblNdP = cfg.NdP_tables[col]
-
-                # sinθ == 0 at an exact pole node (pole-inclusive regular/DH grids):
-                # the tables hold the guarded 0 there, not the true limit, so reading
-                # them would silently zero the entire m=1 contribution on those rows.
-                # Use the closed forms the serial kernels use (src/kernels.jl).
-                is_pole = sθ < SHTnsKit.POLE_TOLERANCE_FACTOR * eps(Float64)
-                @inbounds for l in max(1, mval):lmax
-                    if is_pole
-                        N = cfg.Nlm[l+1, col]
-                        dθY       = SHTnsKit._dPdtheta_at_pole(l, mval, x, N)
-                        Y_over_sθ = SHTnsKit._P_over_sinth_at_pole(l, mval, x, N)
-                    else
-                        dθY       = -sθ * tblNdP[l+1, iglobθ]
-                        Y_over_sθ = tblNP[l+1, iglobθ] * inv_sθ
-                    end
-                    Sl = Slm[l+1, col]
-                    Tl = Tlm[l+1, col]
-                    # Vθ = ∂S/∂θ - (im/sinθ) * T
-                    gθ += dθY * Sl - (0 + 1im) * mval * Y_over_sθ * Tl
-                    # Vφ = (im/sinθ) * S + ∂T/∂θ
-                    gφ += (0 + 1im) * mval * Y_over_sθ * Sl + dθY * Tl
-                end
+            # Shared serial kernels (src/kernels.jl) rather than a third and fourth
+            # inlining of the table/OTF split. Both branches need pole handling the
+            # inline copies got wrong or only half-right:
+            #   * tables hold the guarded 0 at an exact pole node (pole-inclusive
+            #     regular/DH grids, sinθ == 0), not the true limit, so the kernel
+            #     substitutes the closed forms there;
+            #   * OTF must read the pole-safe P̄/sinθ row, NOT P̄ * (1/sinθ) — that
+            #     product is 0 at a pole because inv_sθ is guarded to 0, silently
+            #     dropping the entire m=1 contribution from the pole rows.
+            # `iglobθ` is the cfg-global latitude index cfg.x and the tables share.
+            gθ, gφ = if cfg.use_plm_tables && !isempty(cfg.NP_tables) && !isempty(cfg.NdP_tables)
+                SHTnsKit._sphtor_synthesis_kernel(cfg, Slm, Tlm,
+                                                  cfg.NP_tables[col], cfg.NdP_tables[col],
+                                                  iglobθ, col, mval, lmax)
             else
-                # OTF: normalized rows — P̄, dP̄/dθ, P̄/sinθ; no extra Nlm multiply.
-                SHTnsKit.Plm_norm_dPdtheta_over_sinth_row!(P, dPdtheta, P_over_sth, x, lmax, mval, Pbuf)
-
-                @inbounds for l in max(1, mval):lmax
-                    dθY = dPdtheta[l+1]    # dP̄/dθ already orthonormal-normalized
-                    Y   = P[l+1]           # P̄
-                    Sl = Slm[l+1, col]
-                    Tl = Tlm[l+1, col]
-                    # Vθ = ∂S/∂θ - (im/sinθ) * T
-                    gθ += dθY * Sl - (0 + 1im) * mval * inv_sθ * Y * Tl
-                    # Vφ = (im/sinθ) * S + ∂T/∂θ
-                    gφ += (0 + 1im) * mval * inv_sθ * Y * Sl + dθY * Tl
-                end
+                SHTnsKit._sphtor_synthesis_kernel_otf(cfg, Slm, Tlm, P, dPdtheta, P_over_sth,
+                                                      Pbuf, iglobθ, col, mval, lmax)
             end
 
             # Store Fourier coefficient
@@ -1960,8 +1912,8 @@ function dist_analysis_distributed(cfg::SHTnsKit.SHTConfig, fθφ::PencilArray;
         # Reduce over the θ-column subcomm (ranks sharing this φ-segment) so a 2D
         # (θ×φ) spatial pencil sums each θ-slab once, not once per φ-partner. For
         # φ-complete inputs every rank has the same color → subcomm == full comm.
-        φ_globals_red = collect(globalindices(fθφ, 2))
-        reduce_comm = MPI.Comm_split(comm, Int(first(φ_globals_red)), MPI.Comm_rank(comm))
+        φ_globals_red = collect(Int, globalindices(fθφ, 2))
+        reduce_comm = MPI.Comm_split(comm, _phi_column_color(φ_globals_red), MPI.Comm_rank(comm))
         try
             MPI.Allreduce!(local_contrib, +, reduce_comm)
         finally
@@ -2737,8 +2689,8 @@ function _dist_analysis_2d_safe(cfg::SHTnsKit.SHTConfig, fθφ::PencilArray;
         # 2D (θ×φ) spatial pencil sums each θ-slab once rather than once per
         # φ-partner. For φ-complete inputs the color is identical on every rank,
         # so this subcomm equals plan.comm and behaviour is unchanged.
-        φ_globals_red = collect(globalindices(fθφ, 2))
-        reduce_comm = MPI.Comm_split(comm, Int(first(φ_globals_red)), MPI.Comm_rank(comm))
+        φ_globals_red = collect(Int, globalindices(fθφ, 2))
+        reduce_comm = MPI.Comm_split(comm, _phi_column_color(φ_globals_red), MPI.Comm_rank(comm))
         try
             MPI.Allreduce!(local_contrib, +, reduce_comm)
         finally

--- a/ext/SHTnsKitParallelADExt.jl
+++ b/ext/SHTnsKitParallelADExt.jl
@@ -211,12 +211,16 @@ function ChainRulesCore.rrule(::typeof(SHTnsKit.dist_synthesis_sphtor),
         # One batched Allreduce over stacked (S̄,T̄) instead of two round-trips.
         n = length(S̄p)
         combined = MPI.Allreduce!(vcat(vec(S̄p), vec(T̄p)), +, comm)
-        # `reshape(view(...))` instead of `combined[1:n]`: range indexing copies in
-        # Julia, so the slice form allocated two more full-size arrays on top of the
-        # vcat (~12 MB per backward pass at lmax=511).
-        S̄ = reshape(view(combined, 1:n), size(S̄p))
-        T̄ = reshape(view(combined, (n+1):length(combined)), size(T̄p))
-        return NoTangent(), NoTangent(), S̄, T̄
+        # Scatter back into the matrices `_adjoint_synthesis_sphtor` already
+        # allocated. `combined[1:n]` would allocate two more full-size arrays on
+        # top of the vcat (~12 MB per backward pass at lmax=511), and returning
+        # `reshape(view(combined, …))` avoids that but hands back a ReshapedArray
+        # rather than a Matrix — a downstream distributed pullback that feeds the
+        # tangent straight to `MPI.Allreduce!` then fails buffer conversion.
+        # copyto! reuses S̄p/T̄p, so this is both allocation-free and an Array.
+        copyto!(S̄p, 1, combined, 1, n)
+        copyto!(T̄p, 1, combined, n + 1, length(combined) - n)
+        return NoTangent(), NoTangent(), S̄p, T̄p
     end
     return y, dist_synthesis_sphtor_pullback
 end

--- a/ext/SHTnsKitParallelExt.jl
+++ b/ext/SHTnsKitParallelExt.jl
@@ -776,8 +776,18 @@ function _gather_phi_rows(local_data::AbstractMatrix,
     nlat_local = length(θ_range)
     nlon_local = length(φ_range)
 
-    θ_color = Int(first(θ_range))
+    # A rank owning zero θ rows has no slab to gather, and it must NOT be coloured
+    # by `first(θ_range)`: an empty range still reports `first == 1`, so it would
+    # join the row of the genuine owner of global θ index 1 and trip the
+    # nlat_local consistency check below (killing that row while the other rows
+    # proceed, i.e. a hang). MPI_UNDEFINED — `nothing` in MPI.jl — puts it in no
+    # row at all; Comm_split hands back COMM_NULL and it skips the exchange.
+    θ_color = isempty(θ_range) ? nothing : Int(first(θ_range))
     row_comm = MPI.Comm_split(comm, θ_color, MPI.Comm_rank(comm))
+    if θ_color === nothing
+        _safe_comm_free(row_comm)
+        return Matrix{Float64}(undef, 0, nlon)
+    end
     gathered_data = try
         row_nprocs = MPI.Comm_size(row_comm)
 

--- a/src/api_compat.jl
+++ b/src/api_compat.jl
@@ -161,7 +161,6 @@ function shtns_set_grid(cfg::SHTConfig, flags::Integer, eps::Real, nlat::Integer
     grid_type = f % 256
     south_pole_first = (f & SHT_SOUTH_POLE_FIRST) != 0
     allow_padding = (f & SHT_ALLOW_PADDING) != 0
-    cs_phase, real_norm = _parse_phase_bits(f)
     grid_sym = _grid_symbol(grid_type)
     min_lat = _min_nlat_for_grid(grid_type, cfg.lmax)
     nlat = max(Int(nlat), min_lat)
@@ -210,8 +209,20 @@ function shtns_set_grid(cfg::SHTConfig, flags::Integer, eps::Real, nlat::Integer
     # Same high-bit options `shtns_init` honors — this entry point used to drop
     # them, so `shtns_create` + `shtns_set_grid(..., SHT_NO_CS_PHASE, ...)` kept
     # the default Condon-Shortley phase. Set before prepare_plm_tables! below.
-    cfg.cs_phase = cs_phase
-    cfg.real_norm = real_norm
+    #
+    # Applied only when the caller ASSERTS a bit: in SHTns the phase/normalization
+    # convention is fixed by `shtns_create`'s norm word, and an absent bit in the
+    # *grid* word means "not specified", not "reset to default". Writing the
+    # parsed defaults unconditionally clobbered the canonical
+    # `shtns_create(..., 2 | SHT_NO_CS_PHASE)` + `shtns_set_grid(..., SHT_GAUSS, ...)`
+    # sequence back to CS-phase-on, leaving a half-converted config (Schmidt norm
+    # with CS phase) whose odd-m coefficients all carried the wrong sign.
+    if (f & SHT_NO_CS_PHASE) != 0
+        cfg.cs_phase = false
+    end
+    if (f & SHT_REAL_NORM) != 0
+        cfg.real_norm = true
+    end
 
     # Reset south_pole_first before reconfiguring
     cfg.south_pole_first = false

--- a/src/complex_packed.jl
+++ b/src/complex_packed.jl
@@ -105,6 +105,10 @@ function synthesis_packed_cplx(cfg::SHTConfig, alm_packed::AbstractVector{<:Comp
     inv_scaleφ = phi_inv_scale(cfg)
 
     need_norm = cfg.norm !== :orthonormal || cfg.cs_phase == false
+    # Cached (l,m) scale — norm_scale_from_orthonormal(l,m,cfg.norm) * the CS-phase
+    # factor — the same matrix convert_alm_norm! consumes. Evaluating that product
+    # inside the l-loop repeated it once per latitude for every (l,m).
+    M = _ensure_norm_scale_matrix!(cfg)
     # Complex packed layout stores negative and positive m explicitly, so this
     # loop writes each Fourier bin directly instead of relying on Hermitian
     # symmetry as the real-field packed layout does.
@@ -113,7 +117,6 @@ function synthesis_packed_cplx(cfg::SHTConfig, alm_packed::AbstractVector{<:Comp
     # the norm scale all depend only on |m|, so the +m and -m Fourier bins share
     # the same Legendre row — compute it once instead of twice.
     for am in 0:mmax
-        αm = need_norm ? cs_phase_factor(am, true, cfg.cs_phase) : 1.0
         jp = am + 1                     # DFT bin for +am
         jn = nlon - am + 1              # DFT bin for -am ((j-1) ≡ -am mod nlon)
         for i in 1:nlat
@@ -121,7 +124,7 @@ function synthesis_packed_cplx(cfg::SHTConfig, alm_packed::AbstractVector{<:Comp
             gp = zero(CT); gn = zero(CT)
             @inbounds for l in am:lmax
                 Pl = P[l+1]
-                ns = need_norm ? norm_scale_from_orthonormal(l, am, cfg.norm) * αm : one(αm)
+                ns = need_norm ? M[l+1, am+1] : 1.0
                 ap = alm_packed[LM_cplx_index(lmax, mmax, l, am) + 1]
                 gp += Pl * (need_norm ? ap * ns : ap)
                 if am > 0
@@ -161,13 +164,13 @@ function analysis_packed_cplx(cfg::SHTConfig, z::AbstractMatrix{<:Complex})
     scaleφ = cfg.cphi
 
     need_norm = cfg.norm !== :orthonormal || cfg.cs_phase == false
+    M = _ensure_norm_scale_matrix!(cfg)  # cached (l,m) norm·CS scale; see synthesis_packed_cplx
     xv = cfg.x; wv = cfg.w  # hoist field reads out of the m/l loops (cfg is mutable, so not auto-hoisted)
     # Read both signs of m from the FFT output and store them in LM_cplx order.
     # Negative modes live at DFT column nlon+m+1. Loop over |m| once — P̄_l^{|m|},
     # the CS-phase factor and the norm scale depend only on |m| — so the +m and
     # -m columns share one Legendre row instead of recomputing it twice.
     for am in 0:mmax
-        αm = need_norm ? cs_phase_factor(am, true, cfg.cs_phase) : 1.0
         colp = am + 1
         coln = cfg.nlon - am + 1
         for i in 1:cfg.nlat
@@ -177,7 +180,7 @@ function analysis_packed_cplx(cfg::SHTConfig, z::AbstractMatrix{<:Complex})
             Fin = am > 0 ? Fφ[i, coln] : zero(eltype(Fφ))
             @inbounds for l in am:lmax
                 base = (wi * P[l+1]) * scaleφ
-                ns = need_norm ? norm_scale_from_orthonormal(l, am, cfg.norm) * αm : one(αm)
+                ns = need_norm ? M[l+1, am+1] : 1.0
                 ap = base * Fip
                 need_norm && (ap /= ns)
                 alm[LM_cplx_index(lmax, mmax, l, am) + 1] += ap
@@ -206,15 +209,15 @@ function synthesis_point_cplx(cfg::SHTConfig, alm::AbstractVector{<:Complex}, co
     P = Vector{Float64}(undef, lmax + 1)
     acc = zero(CT)
     need_norm = cfg.norm !== :orthonormal || cfg.cs_phase == false
+    M = _ensure_norm_scale_matrix!(cfg)  # cached (l,m) norm·CS scale; see synthesis_packed_cplx
     # Loop over |m| once (P̄_l^{|m|}, CS-phase and norm scale depend only on |m|)
     # and accumulate the +m and -m contributions from the shared Legendre row.
     for am in 0:mmax
         Plm_norm_row!(P, x, lmax, am)
-        αm = need_norm ? cs_phase_factor(am, true, cfg.cs_phase) : 1.0
         gp = zero(CT); gn = zero(CT)
         @inbounds for l in am:lmax
             Pl = P[l+1]
-            ns = need_norm ? norm_scale_from_orthonormal(l, am, cfg.norm) * αm : one(αm)
+            ns = need_norm ? M[l+1, am+1] : 1.0
             ap = alm[LM_cplx_index(lmax, mmax, l, am) + 1]
             gp += Pl * (need_norm ? ap * ns : ap)
             if am > 0

--- a/test/parallel/test_mpi_audit_fixes.jl
+++ b/test/parallel/test_mpi_audit_fixes.jl
@@ -9,6 +9,10 @@
 #   3. sphtor table kernels: closed-form pole limits instead of the guarded 0
 #   4. ranks owning zero φ columns (nranks > nlon) must not crash the φ gather
 #   5. 2D (θ×φ) pencil: θ-slab reduction must not over-count φ-partners
+#   6. 2D pencil with an empty θ-partition: the slab keeper must still be a rank
+#      that owns θ rows, or a whole latitude slab drops out of the sum
+#   7. sphtor pole limits on the OTF (no-table) branch, not just the table branch
+#   8. complex dist_analysis_packed_cplx on a φ-decomposed pencil
 #
 # Run with: mpiexec -n 4 julia --project test/parallel/test_mpi_audit_fixes.jl
 
@@ -206,6 +210,93 @@ max_local_error(pa::PencilArray, F::AbstractMatrix) =
                 @test isapprox(T_d, Tref; rtol=1e-8, atol=1e-10)
                 root_println("    [PASS] 2D pencil reduction")
             end
+        end
+    end
+
+    @testset "2D pencil with an empty θ-partition" begin
+        # More θ-partitions than latitudes, so at least one rank owns zero θ rows.
+        # Electing the slab keeper by θ-colour put such a rank in the same
+        # Comm_split group as the genuine owner of global θ index 1 (an empty
+        # range still reports `first == 1`), and Comm_split orders by global rank
+        # — so the empty rank could win group rank 0 and zero the real θ=1 slab
+        # out of the reduction, silently dropping a whole latitude band.
+        lmax = 2
+        nlat, nlon = lmax + 1, 2*lmax + 1
+        # An automatic topology will not leave a θ-partition empty, so pick the
+        # process grid explicitly: pθ > nlat forces the empty partition, pφ ≥ 2
+        # keeps the φ-partner dedup (the code under test) on the critical path.
+        pθ = 0
+        for p in (nlat + 1):nprocs
+            if nprocs % p == 0 && nprocs ÷ p >= 2
+                pθ = p
+                break
+            end
+        end
+        if pθ == 0
+            root_println("    [SKIP] no (pθ>$nlat, pφ≥2) split of $nprocs ranks; needs e.g. 8")
+            @test true
+        else
+            pφ = nprocs ÷ pθ
+            pen2 = Pencil(MPITopology(comm, (pθ, pφ)), (nlat, nlon), (1, 2))
+            cfg = create_gauss_config(lmax, nlat; nlon=nlon)
+            r = PencilArrays.range_local(pen2)
+            n_empty_θ = MPI.Allreduce(isempty(r[1]) ? 1 : 0, +, comm)
+            @test n_empty_θ > 0     # the scenario really is set up
+            rng = MersenneTwister(31337)
+            F = randn(rng, nlat, nlon)
+            @test isapprox(SHTnsKit.dist_analysis(cfg, scatter_field(pen2, F)),
+                           SHTnsKit.analysis(cfg, F); rtol=1e-9, atol=1e-11)
+            root_println("    [PASS] empty θ-partition ($(pθ)×$(pφ) grid, $n_empty_θ empty ranks)")
+        end
+    end
+
+    @testset "sphtor pole limits on the OTF branch" begin
+        # precompute_plm=false forces the on-the-fly branch, which computed
+        # Y/sinθ as P̄ * (1/sinθ). At an exact pole node 1/sinθ is guarded to 0,
+        # so that product is 0 and the entire m=1 contribution vanished from the
+        # pole rows — while the table branch next to it had already been fixed.
+        lmax = 6
+        for precompute in (false, true)
+            cfg = create_regular_config(lmax, lmax + 2; nlon=2*lmax + 3,
+                                        include_poles=true, precompute_plm=precompute)
+            rng = MersenneTwister(4242)
+            Slm = zeros(ComplexF64, lmax+1, cfg.mmax+1)
+            Tlm = zeros(ComplexF64, lmax+1, cfg.mmax+1)
+            for m in 0:cfg.mmax, l in max(1, m):lmax
+                Slm[l+1, m+1] = randn(rng, ComplexF64)
+                Tlm[l+1, m+1] = randn(rng, ComplexF64)
+            end
+            Slm[:, 1] .= real.(Slm[:, 1]); Tlm[:, 1] .= real.(Tlm[:, 1])
+
+            Vt_ref, Vp_ref = SHTnsKit.synthesis_sphtor(cfg, Slm, Tlm; real_output=true)
+            # Guard against a vacuous pass: the pole rows must carry signal.
+            @test maximum(abs, view(Vt_ref, 1, :)) > 1e-6
+
+            pen = Pencil((cfg.nlat, cfg.nlon), (1,), comm)
+            proto = PencilArray{Float64}(undef, pen)
+            Vt_d, Vp_d = SHTnsKit.dist_synthesis_sphtor(cfg, Slm, Tlm;
+                                                        prototype_θφ=proto, real_output=true)
+            @test max_local_error(Vt_d, Vt_ref, pen) < 1e-10
+            @test max_local_error(Vp_d, Vp_ref, pen) < 1e-10
+        end
+        root_println("    [PASS] sphtor OTF pole limits")
+    end
+
+    @testset "complex packed_cplx on a φ-decomposed pencil" begin
+        # The complex path routed the field through dist_analysis, whose φ-gather
+        # helper packs into a Vector{Float64} — so a ComplexF64 PencilArray threw
+        # InexactError on every rank. Only the θ-decomposed layout was covered.
+        lmax = 5
+        nlat, nlon = lmax + 2, 2*lmax + 2
+        cfg = create_gauss_config(lmax, nlat; nlon=nlon)
+        rng = MersenneTwister(909)
+        zref = randn(rng, ComplexF64, nlat, nlon)
+        ref = SHTnsKit.analysis_packed_cplx(cfg, zref)
+        for (label, pen) in (("φ-split", Pencil((nlat, nlon), comm)),
+                             ("θ-split", Pencil((nlat, nlon), (1,), comm)))
+            got = SHTnsKit.dist_analysis_packed_cplx(cfg, scatter_field(pen, zref))
+            @test isapprox(got, ref; rtol=1e-9, atol=1e-11)
+            root_println("    [PASS] complex packed_cplx on $label pencil")
         end
     end
 end

--- a/test/serial/test_api_compat.jl
+++ b/test/serial/test_api_compat.jl
@@ -103,11 +103,30 @@ using SHTnsKit
                              1e-10, lmax + 3, 2*mmax + 3) == 0
         @test cfg.cs_phase == false
         @test cfg.real_norm == true
+    end
 
-        # And back off again — the flags are read fresh on every call.
+    @testset "shtns_set_grid preserves the create-time convention" begin
+        # The bits are asserted, not reset: in SHTns the phase/normalization
+        # convention belongs to shtns_create's norm word, and a *grid* word
+        # without the bit means "unspecified". A regrid must therefore leave a
+        # create-time SHT_NO_CS_PHASE alone — applying the grid word's defaults
+        # unconditionally left Schmidt norm with CS phase back on, flipping the
+        # sign of every odd-m coefficient relative to SHTns.
+        lmax, mmax = 5, 5
+        cfg = shtns_create(lmax, mmax, 1, 2 | SHT_NO_CS_PHASE)
+        @test cfg.norm == :schmidt
+        @test cfg.cs_phase == false
+
         @test shtns_set_grid(cfg, SHT_GAUSS, 1e-10, lmax + 3, 2*mmax + 3) == 0
-        @test cfg.cs_phase == true
+        @test cfg.norm == :schmidt
+        @test cfg.cs_phase == false
         @test cfg.real_norm == false
+
+        # Same for real_norm, which shtns_create can also set.
+        cfg2 = shtns_create(lmax, mmax, 1, SHT_REAL_NORM)
+        @test cfg2.real_norm == true
+        @test shtns_set_grid(cfg2, SHT_GAUSS, 1e-10, lmax + 3, 2*mmax + 3) == 0
+        @test cfg2.real_norm == true
     end
 
     @testset "shtns_create parses norm bits" begin


### PR DESCRIPTION
Follow-up review of the audit branch merged in #27. Three of the four correctness
bugs it turned up were introduced by that branch's own fixes.

## `first(1:0) == 1` poisons every `Comm_split` colour

Julia's empty range still answers `first`. Any colour derived from
`first(globals)` therefore groups a rank owning **zero** of that dimension with
the genuine owner of global index 1 — and `Comm_split` orders by global rank, so
the empty rank can win group rank 0. Three sites:

| site | symptom |
|---|---|
| `_keep_one_phi_partner!` | a zero-θ rank elected slab keeper zeroes the **real** θ=1 slab out of the reduction — a whole latitude band silently missing |
| `_gather_phi_rows` | zero-θ rank joins the θ=1 row, trips its `nlat_local` guard, kills that row while other rows proceed → **hang** |
| 2 reduction sites + 2 plan constructors | raw `first(φ_globals)` BoundsErrors an empty-φ rank *inside* a collective |

Fixes, respectively: drop the split entirely (the keeper is the φ-partner owning
global φ index 1 — exactly one per θ-slab by construction, decided locally, which
also removes a synchronizing collective plus a communicator allocate/free from
every 2D-pencil analysis call); colour with `MPI_UNDEFINED` and skip the
exchange; a new `_phi_column_color` that folds an empty-φ rank into the column
owning φ index 1, where it contributes zeros and receives the complete sum.

## Sphtor pole limits reached only the table branch

The OTF twin still computed `Y/sinθ` as `inv_sθ * P[l+1]`, and `inv_sθ` is
guarded to 0 at a pole — so the entire m=1 contribution vanished from the pole
rows. Measured at the exact pole: `-0.0` where the correct value is `-0.3455`.

All three distributed sphtor loops now call the serial kernels in
`src/kernels.jl` rather than carrying a fourth hand-copy of the pole branch, so
the serial and distributed paths cannot drift. The planned-path allocation budget
is unchanged: `dist_analysis_sphtor! (tables)` still measures **0 B/call**.

## `shtns_set_grid` no longer clobbers the create-time convention

The phase/normalization bits are now applied only when the caller *asserts* them;
an absent bit in the grid word means unspecified, not reset. Writing the parsed
defaults unconditionally meant the canonical
`shtns_create(…, 2 | SHT_NO_CS_PHASE)` + `shtns_set_grid(…, SHT_GAUSS, …)`
sequence came back with Schmidt norm **and** CS phase back on, flipping the sign
of every odd-m coefficient. The test that pinned the clobbering was rewritten.

## Also

- `dist_analysis_packed_cplx` splits a complex field into real/imag instead of
  transforming `conj(z)`. Analysis is ℂ-linear, so two real transforms give both
  halves — and real data survives the φ-gather, which packs into a
  `Vector{Float64}` and threw `InexactError` on every rank for a ComplexF64
  PencilArray on a φ-decomposed pencil.
- The distributed sphtor AD pullback copies reduced values back into the matrices
  the adjoint already allocated. `reshape(view(combined, …))` is not an `Array`,
  so the tangent failed buffer conversion when a downstream pullback handed it
  straight to `MPI.Allreduce!`.
- `complex_packed.jl` reads the cached `_ensure_norm_scale_matrix!` instead of
  recomputing the norm·CS-phase product per latitude inside the l-loop (4 sites).

## Tests

Three new regression testsets covering the gaps that let these through:

- **empty θ-partition** — needs an explicit `pθ > nlat × pφ ≥ 2` `MPITopology`,
  because an automatic one never produces the case. This is the test that
  surfaced the `_gather_phi_rows` hang.
- **OTF pole branch** — `precompute_plm=false`, with an assertion that the pole
  rows actually carry signal so the test cannot pass vacuously.
- **complex packed analysis on a φ-decomposed pencil** — the previous test only
  exercised the θ-decomposed layout.

Serial 67268/0/0. Every MPI file exits 0 at 2/3/4 ranks; `test_mpi_audit_fixes.jl`
also at 8 ranks (required for the empty-θ case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)