### PR TITLE
Remove dead normalization machinery left by the orthonormal refactor

### DIFF
--- a/ext/ParallelTransposeTransforms.jl
+++ b/ext/ParallelTransposeTransforms.jl
@@ -64,14 +64,12 @@ Constructed via `DistTransposePlan(cfg; comm, nlev, use_rfft, with_vector)`.
 - `NP`              : `NP[mi]` = `(lmax+1, nlat)` matrix of P̄_l^{m_local[mi]}(cos θ_i)
 - `dP`              : `dP[mi]` = `(lmax+1, nlat)` matrix of dP̄_l^m/dθ at each latitude
 - `Pos`             : `Pos[mi]` = `(lmax+1, nlat)` matrix of P̄_l^m/sinθ at each latitude
-- `need_norm`       : whether `cfg` uses a non-internal convention (`norm !== :orthonormal`
-                       or `cs_phase == false`), so coefficients need converting
-- `Mloc`            : `(lmax+1, length(m_local))` external↔internal scale for the local m's,
-                       i.e. `norm_scale_from_orthonormal(l,m,cfg.norm) * cs_phase_factor(m,…)`
 
-Coefficients crossing this plan's API are in **cfg's convention**, matching
-`dist_analysis`/`dist_synthesis` and the `dist_analysis_sphtor` family. The
-Legendre tables are orthonormal, so the transforms convert with `Mloc`.
+Coefficients crossing this plan's API are **orthonormal**, like every other
+transform in the package (serial `analysis`/`synthesis`, the `dist_*` family and
+the energy diagnostics). The Legendre tables are orthonormal too, so no
+normalization conversion happens anywhere on this path. Callers wanting another
+convention apply `convert_alm_norm!` themselves.
 """
 struct DistTransposePlan{TP, TFB, TSP}
     cfg           :: SHTnsKit.SHTConfig
@@ -90,44 +88,8 @@ struct DistTransposePlan{TP, TFB, TSP}
     dP            :: Vector{Matrix{Float64}} # dP[mi] = (lmax+1, nlat) dP̄_l^m/dθ table
     Pos           :: Vector{Matrix{Float64}} # Pos[mi] = (lmax+1, nlat) P̄_l^m/sinθ table
     with_vector   :: Bool                    # whether dP/Pos were built (sphtor/qst capable)
-    need_norm     :: Bool                    # cfg.norm !== :orthonormal || !cfg.cs_phase
-    Mloc          :: Matrix{Float64}         # (lmax+1, n_m_local) cfg↔internal scale
-    alm_scratch   :: Array{ComplexF64,3}     # synthesis-side conversion buffer (empty unless need_norm)
 end
 
-"""
-    _scale_alm_to_internal!(A, plan)
-    _scale_alm_to_cfg!(A, plan)
-
-Convert a local spectral parent array `A[l+1, mi, lev]` between cfg's
-normalization/phase and the internal orthonormal+CS form the Legendre tables
-expect. No-ops unless `plan.need_norm`. Applied once per call outside the θ loop,
-so the (default) orthonormal path costs nothing and the converted path adds
-O(lmax·m_local·nlev) rather than a multiply per (l, θ).
-"""
-@inline function _scale_alm_to_internal!(A::AbstractArray, plan::DistTransposePlan)
-    plan.need_norm || return A
-    M = plan.Mloc
-    @inbounds for lev in axes(A, 3), mi in eachindex(plan.m_local)
-        m = plan.m_local[mi]
-        for l in m:plan.lmax
-            A[l+1, mi, lev] *= M[l+1, mi]
-        end
-    end
-    return A
-end
-
-@inline function _scale_alm_to_cfg!(A::AbstractArray, plan::DistTransposePlan)
-    plan.need_norm || return A
-    M = plan.Mloc
-    @inbounds for lev in axes(A, 3), mi in eachindex(plan.m_local)
-        m = plan.m_local[mi]
-        for l in m:plan.lmax
-            A[l+1, mi, lev] /= M[l+1, mi]
-        end
-    end
-    return A
-end
 
 # ---------------------------------------------------------------------------
 # Constructor
@@ -248,37 +210,11 @@ function SHTnsKit.DistTransposePlan(
     #    convention (as `dist_analysis`/`dist_synthesis` do), so the transforms
     #    convert with this matrix. Without it a `norm=:schmidt` or
     #    `cs_phase=false` config silently disagreed with the cfg-form paths.
-    # The transpose path is ORTHONORMAL-only, like every other distributed
-    # transform and serial `analysis`/`synthesis`. `need_norm` is therefore always
-    # false; the Mloc/scratch machinery is retained but inert so the struct and
-    # the (no-op) scale helpers keep a single shape.
-    need_norm = false
-    #    Allocated only when it is actually consulted, so a default-config plan
-    #    carries neither the scale matrix nor the conversion scratch.
-    Mloc = if need_norm
-        Mfull = SHTnsKit._ensure_norm_scale_matrix!(cfg)
-        M = Matrix{Float64}(undef, lmax + 1, length(m_local))
-        fill!(M, 1.0)
-        for (mi, m) in enumerate(m_local), l in m:lmax
-            M[l+1, mi] = Mfull[l+1, m+1]
-        end
-        M
-    else
-        Matrix{Float64}(undef, 0, 0)
-    end
-    #    Synthesis must not mutate the caller's coefficients, so it converts into
-    #    a buffer. Allocating that buffer per call (~32 MB at lmax=511, 64 local
-    #    m's, nlev=64) would break this plan's whole zero-allocation design point,
-    #    so it is owned by the plan and reused. Sized for the FULL local column
-    #    count, which on a dealiased grid exceeds length(m_local).
-    n_cols_local = length(range_local(spectral_pencil)[2])
-    alm_scratch = need_norm ? Array{ComplexF64,3}(undef, lmax + 1, n_cols_local, nlev) :
-                              Array{ComplexF64,3}(undef, 0, 0, 0)
 
     return DistTransposePlan(
         cfg, nlat, nlon, lmax, mmax, nlev, comm,
         fft_plan, F_buf, F_buf2, spectral_pencil,
-        m_local, NP, dP, Pos, with_vector, need_norm, Mloc, alm_scratch,
+        m_local, NP, dP, Pos, with_vector,
     )
 end
 
@@ -339,8 +275,6 @@ function SHTnsKit.dist_analysis!(plan::DistTransposePlan, Alm::PencilArray, f::P
             end
         end
     end
-    # Tables are orthonormal; hand back coefficients in cfg's convention.
-    _scale_alm_to_cfg!(A, plan)
     return Alm
 end
 
@@ -377,9 +311,6 @@ function SHTnsKit.dist_synthesis!(plan::DistTransposePlan, f::PencilArray, Alm::
     # Incoming coefficients are in cfg's convention; the tables are orthonormal.
     # Convert a copy so the caller's array is left untouched (no-op, and no
     # allocation, on the default orthonormal+CS config).
-    if plan.need_norm
-        A = _scale_alm_to_internal!(copyto!(view(plan.alm_scratch, :, axes(A, 2), :), A), plan)
-    end
 
     # Legendre expansion: for each local m, sum over l → F[i, mi, lev]
     # NP[mi] is (lmax+1, nlat) column-major; iterating i (fast dim of F) is cache-friendly.
@@ -465,9 +396,6 @@ function SHTnsKit.dist_analysis_sphtor!(plan::DistTransposePlan,
             end
         end
     end
-    # Tables are orthonormal; hand back coefficients in cfg's convention.
-    _scale_alm_to_cfg!(S, plan)
-    _scale_alm_to_cfg!(T, plan)
     return Slm, Tlm
 end
 
@@ -503,12 +431,6 @@ function SHTnsKit.dist_synthesis_sphtor!(plan::DistTransposePlan,
 
     # Incoming coefficients are in cfg's convention; convert copies (no-op on the
     # default orthonormal+CS config) so the caller's arrays are left untouched.
-    if plan.need_norm
-        # Two buffers are needed at once, so S borrows the plan scratch and T
-        # takes a fresh copy; only the S half is amortized.
-        S = _scale_alm_to_internal!(copyto!(view(plan.alm_scratch, :, axes(S, 2), :), S), plan)
-        T = _scale_alm_to_internal!(copy(T), plan)
-    end
 
     # Legendre expansion: for each local m, sum over l → Ft[i,mi,lev], Fp[i,mi,lev]
     # Kernel (from kernels.jl _sphtor_synthesis_kernel_otf):

--- a/ext/SHTnsKitAdvancedADExt.jl
+++ b/ext/SHTnsKitAdvancedADExt.jl
@@ -51,17 +51,6 @@ import SHTnsKit: wigner_d_matrix_deriv
     @inline _materialize_coeff(A, cfg) =
         A isa ChainRulesCore.AbstractZero ? _coeff_zeros(cfg) : _to_complex(A)
 
-    # `AbstractZero` (ZeroTangent/NoTangent) must pass straight through: a loss
-    # that consumes only one of two outputs hands the other slot a ZeroTangent,
-    # and `similar(::ZeroTangent)` is a MethodError.
-    @inline _scale_cotangent(A::ChainRulesCore.AbstractZero, cfg; to_internal::Bool) = A
-
-    @inline function _scale_cotangent(A, cfg; to_internal::Bool)
-        _needs_norm(cfg) || return A
-        out = similar(A)
-        SHTnsKit.convert_alm_norm!(out, A, cfg; to_internal=to_internal)
-        return out
-    end
 
     function ChainRulesCore.rrule(::typeof(SHTnsKit.analysis), cfg::SHTnsKit.SHTConfig, f)
         y = SHTnsKit.analysis(cfg, f)

--- a/ext/SHTnsKitParallelADExt.jl
+++ b/ext/SHTnsKitParallelADExt.jl
@@ -75,34 +75,6 @@ a separate extension module and cannot see it.
     return false, φ_start:(φ_start + nlon_local - 1)
 end
 
-"""
-    _scale_cotangent(A, cfg; to_internal)
-
-Apply the config's normalization/phase scale `M` to a coefficient cotangent.
-
-Every distributed transform exchanges coefficients in **cfg's** convention while
-the `_adjoint_*` kernels work in the internal orthonormal+CS one, so the
-conversion is part of the operator and must appear in its adjoint:
-
-    synthesis-like   y = F(M ⊙ a)     ⇒   ā = M ⊙ Fᴴ(ȳ)
-    analysis-like    a = F(x) ⊘ M     ⇒   x̄ = Fᴴ(ā ⊘ M)
-
-`M` is real and diagonal, so there is no conjugation to worry about. Without
-this, every non-default `cfg.norm` / `cs_phase` gradient was wrong by M[l,m]
-(finite differences: 40–180% relative error on :schmidt and :fourpi). No-op —
-and no allocation — on the default config.
-"""
-# `AbstractZero` (ZeroTangent/NoTangent) passes through untouched — a loss that
-# consumes only one output hands the other slot a ZeroTangent, and
-# `similar(::ZeroTangent)` is a MethodError.
-@inline _scale_cotangent(A::ChainRulesCore.AbstractZero, cfg; to_internal::Bool) = A
-
-@inline function _scale_cotangent(A, cfg; to_internal::Bool)
-    (cfg.norm !== :orthonormal || cfg.cs_phase == false) || return A
-    out = similar(A)
-    SHTnsKit.convert_alm_norm!(out, A, cfg; to_internal=to_internal)
-    return out
-end
 
 # The rank-local adjoint is just the parametrized `SHTnsKit._adjoint_analysis`
 # called with a restricted θ subset and optional φ-window.

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -134,8 +134,6 @@ struct SHTPlan{FP, IP, RP, IRP}
     rfft_plan::RP                 # Real→complex FFT plan (nothing when use_rfft=false)
     irfft_plan::IRP               # Complex→real inverse FFT plan (nothing when use_rfft=false)
     use_rfft::Bool                # Flag: true = use real FFT optimization, false = complex FFT
-    norm_tmp1::Matrix{ComplexF64} # Scratch buffer for normalization conversion
-    norm_tmp2::Matrix{ComplexF64} # Second scratch buffer for vector normalization conversion
 end
 
 """
@@ -192,13 +190,9 @@ function SHTPlan(cfg::SHTConfig; use_rfft::Bool=false)
         irfft_plan = nothing
     end
 
-    # Pre-allocate normalization scratch buffers for zero-allocation in-place transforms
-    norm_tmp1 = Matrix{ComplexF64}(undef, cfg.lmax + 1, cfg.mmax + 1)
-    norm_tmp2 = Matrix{ComplexF64}(undef, cfg.lmax + 1, cfg.mmax + 1)
-
+    # No normalization scratch: the package is orthonormal-only, so nothing converts.
     return SHTPlan(cfg, P, dPdx, dPdtheta, P_over_sinth, Pb, G, Fθk, Fθk_r, real_scratch,
-                   fft_plan, ifft_plan, rfft_plan, irfft_plan, use_rfft,
-                   norm_tmp1, norm_tmp2)
+                   fft_plan, ifft_plan, rfft_plan, irfft_plan, use_rfft)
 end
 
 """


### PR DESCRIPTION
Follow-up to #29, which merged before this landed.

With no code path converting normalization any more, several helpers and struct fields became unreachable:

- **`SHTPlan.norm_tmp1` / `norm_tmp2`** — two `(lmax+1)×(mmax+1)` ComplexF64 buffers allocated per plan that nothing reads
- **`DistTransposePlan.need_norm` / `Mloc` / `alm_scratch`**, plus `_scale_alm_to_internal!` and `_scale_alm_to_cfg!` — `need_norm` was hardcoded `false`, so the whole machinery was inert
- **`_scale_cotangent`** — in *both* AD extensions, no call sites left

The `DistTransposePlan` docstring still listed the removed fields and declared that *"coefficients crossing this plan's API are in cfg's convention"* — the opposite of what the code does. Rewritten to state the orthonormal contract.

## Verification

Serial **67278/67278**; 8 MPI suites at 4 ranks; 56 custom assertions at 8 ranks. Cross-API equality unchanged at machine precision, and still identical across `:orthonormal` / `:schmidt` / `:fourpi`:

| Check | Value |
|---|---|
| QST roundtrip | 1.2e-15 |
| `SHTPlan` sphtor == non-plan | 4.4e-16 |
| `SHqst_to_point` == its grid | 2.2e-16 |
| `packed_cplx` == dense synthesis | 0.0e+00 |

## ⚠️ Review gap worth knowing about

The adversarial review I ran against #29's final commit (`f19a2bcb`, a 241-line bulk-regex deletion) **did not actually complete** — 4 of its 5 agents died on an API session limit, so it produced zero candidates and reported "no findings" vacuously. That commit merged without an independent review pass.

That matters because one regex in that commit had already silently deleted live code (`analysis_qst` lost its transform calls; caught only by an `UndefVarError` in the suite). The test suite is green and I checked the obvious failure modes by hand, but a proper review of `f19a2bcb` is still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
